### PR TITLE
Fixed missing key error

### DIFF
--- a/trycourier/exceptions.py
+++ b/trycourier/exceptions.py
@@ -5,7 +5,7 @@ class CourierAPIException(Exception):
     def __init__(self, response):
         self.response = response
         respJSON = response.json()
-        msg = respJSON["Message"] or respJSON["message"]
+        msg = respJSON.get("Message") or respJSON.get("message")
         self.message = "Call to {uri} returned {status_code}\n{msg}".format(
             uri=response.url,
             status_code=response.status_code,


### PR DESCRIPTION
## Description of the change

> `respJSON["Message"]` will throw an error if the key doesn't exist. Need to use `respJSON.get("Message")`

## Type of change
- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 