### PR TITLE
Added missing decorators for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release. Supports Python 3.5+. Supports Send API.
 
-[v1.1.0]: https://github.com/trycourier/courier-python/compare/1.0.0...1.1.0
+[v1.1.0]: https://github.com/trycourier/courier-python/compare/v1.0.0...v1.1.0
 [@aydrian]: https://github.com/aydrian

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -69,6 +69,7 @@ def test_success_send_with_options():
     assert request_params["override"] == {'provider': {}}
 
 
+@responses.activate
 def test_fail_send():
     responses.add(
         responses.POST,
@@ -103,6 +104,7 @@ def test_success_get_profile():
     assert r == {"profile": {"email": "test@example.com"}}
 
 
+@responses.activate
 def test_fail_get_profile():
     responses.add(
         responses.GET,
@@ -138,6 +140,7 @@ def test_success_replace_profile():
     assert r == {"status": "SUCCESS"}
 
 
+@responses.activate
 def test_fail_replace_profile():
     responses.add(
         responses.PUT,
@@ -177,6 +180,7 @@ def test_success_merge_profile():
     assert r == {"status": "SUCCESS"}
 
 
+@responses.activate
 def test_fail_merge_profile():
     responses.add(
         responses.POST,


### PR DESCRIPTION
## Description of the change

Noticed a few tests were missing the `@responses.activate` decorator which caused them to actually make the request. The test was passing because it was still returning a status code of >= 400. The were showing up in our logs as failures. This change does not require a publish.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 