### PR TITLE
Add client support for get message status

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,3 +198,21 @@ def test_fail_merge_profile():
 
     with pytest.raises(CourierAPIException):
         c.merge_profile("1234", profile)
+
+
+@responses.activate
+def test_success_get_message_status():
+    responses.add(
+        responses.GET,
+        'https://api.trycourier.app/messages/1234',
+        status=200,
+        content_type='application/json',
+        body='{"status": "DELIVERED"}'
+    )
+
+    c = Courier(auth_token='123456789ABCDF')
+    r = c.get_message_status(
+        message_id='1234',
+    )
+
+    assert r == {"status": "DELIVERED"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,3 +216,21 @@ def test_success_get_message():
     )
 
     assert r == {"status": "DELIVERED"}
+
+
+@responses.activate
+def test_fail_get_message():
+    responses.add(
+        responses.GET,
+        'https://api.trycourier.app/messages/1234',
+        status=400,
+        content_type='application/json',
+        body='{"message": "An error occurred"}'
+    )
+
+    c = Courier(auth_token='123456789ABCDF')
+
+    with pytest.raises(CourierAPIException):
+        c.get_message(
+            message_id='1234',
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -201,7 +201,7 @@ def test_fail_merge_profile():
 
 
 @responses.activate
-def test_success_get_message_status():
+def test_success_get_message():
     responses.add(
         responses.GET,
         'https://api.trycourier.app/messages/1234',
@@ -211,7 +211,7 @@ def test_success_get_message_status():
     )
 
     c = Courier(auth_token='123456789ABCDF')
-    r = c.get_message_status(
+    r = c.get_message(
         message_id='1234',
     )
 

--- a/trycourier/client.py
+++ b/trycourier/client.py
@@ -200,4 +200,3 @@ class Courier(object):
             raise CourierAPIException(resp)
 
         return resp.json()
-

--- a/trycourier/client.py
+++ b/trycourier/client.py
@@ -177,7 +177,7 @@ class Courier(object):
 
         return resp.json()
 
-    def get_message_status(self, message_id):
+    def get_message(self, message_id):
         """
         Get the status of the message corresponding to message_id.
 

--- a/trycourier/client.py
+++ b/trycourier/client.py
@@ -176,3 +176,28 @@ class Courier(object):
             raise CourierAPIException(resp)
 
         return resp.json()
+
+    def get_message_status(self, message_id):
+        """
+        Get the status of the message corresponding to message_id.
+
+        Args:
+            message_id (str): A unique identifier representing the
+            message associated with the requested message.
+
+        Raises:
+            CourierAPIException: Any error returned by the Courier API
+
+        Returns:
+            dict: Contains a success, as well as details
+        """
+
+        url = "%s/%s/%s" % (self.base_url, "messages", message_id)
+
+        resp = self.session.get(url)
+
+        if resp.status_code >= 400:
+            raise CourierAPIException(resp)
+
+        return resp.json()
+


### PR DESCRIPTION
## Description of the change

Adds support for fetching the status of an already-sent message: https://docs.trycourier.com/reference#messages-api

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development