### PR TITLE
Handle timeouts

### DIFF
--- a/trycourier/client.py
+++ b/trycourier/client.py
@@ -12,7 +12,8 @@ class Courier(object):
                  base_url='https://api.trycourier.app',
                  auth_token=None,
                  username=None,
-                 password=None):
+                 password=None,
+                 timeout=5):
         """
         Instantiate a new API client.
         Args:
@@ -20,11 +21,13 @@ class Courier(object):
           auth_token (str): Auth Token used for Token Auth
           username (str): Username used for Basic Auth
           password (str): Password used for Basic Auth
+          timeout (float|tuple): Timeout in seconds. (Connect, Read) Defaults
+          to 5 seconds for both.
         """
         self.base_url = base_url
 
         # Initialize the session.
-        self.session = CourierAPISession()
+        self.session = CourierAPISession(timeout)
         self.session.init_library_version(__version__)
 
         # Pass auth creds to the session

--- a/trycourier/session.py
+++ b/trycourier/session.py
@@ -1,10 +1,22 @@
 from base64 import b64encode
 from requests import Session
+from requests.adapters import HTTPAdapter
+
+
+class MyHTTPAdapter(HTTPAdapter):
+
+    def __init__(self, timeout=None, *args, **kwargs):
+        self.timeout = timeout
+        super(MyHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        kwargs['timeout'] = self.timeout
+        return super(MyHTTPAdapter, self).send(*args, **kwargs)
 
 
 class CourierAPISession(Session):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, timeout=5, *args, **kwargs):
         """
         Creates a new CoreAPISession instance.
         """
@@ -13,6 +25,8 @@ class CourierAPISession(Session):
         self.headers.update({
             'Content-Type': 'application/json'
         })
+
+        self.mount("https://", MyHTTPAdapter(timeout=timeout))
 
     def init_library_version(self, version):
         self.headers.update({


### PR DESCRIPTION
## Description of the change
There is not default timeout for the Python requests library.
Added a configurable timeout to the CourierAPISession. This can be set using the `timeout` parameter. It defaults to 5.

I have tested this by setting the timeout to a very low number. 0.1 secs will raise the timeout exception.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 