### PR TITLE
[C-9804] - add support for cancel message api

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.10.12]
 
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v1
         with:
-          python-version: "3.x"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v4.5.0] - 2022-07-26
+
+Adds support for Cancel Message API
+
 ## [v4.4.0] - 2022-07-26
 
 Adds support for Audit Events API

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="trycourier",
-    version="4.4.0",
+    version="4.5.0",
     author="Courier",
     author_email="support@courier.com",
     description="A Python Package for communicating with the Courier REST API.",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,6 +4,7 @@ import pytest
 from trycourier.client import Courier
 from trycourier.exceptions import CourierAPIException
 
+
 @responses.activate
 def test_success_messages_list():
     responses.add(
@@ -99,7 +100,8 @@ def test_success_messages_get_history():
     c = Courier(auth_token='123456789ABCDF')
     r = c.messages.get_history(message_id="my.message.id")
 
-    assert r == {'results':[]}
+    assert r == {'results': []}
+
 
 @responses.activate
 def test_success_messages_get_history_with_params():
@@ -114,7 +116,7 @@ def test_success_messages_get_history_with_params():
     c = Courier(auth_token='123456789ABCDF')
     r = c.messages.get_history(message_id="my.message.id", type="my.type")
 
-    assert r == {'results':[]}
+    assert r == {'results': []}
 
 
 @responses.activate
@@ -133,6 +135,17 @@ def test_fail_messages_get_history():
         c.messages.get_history("my.message.id")
 
 
+@responses.activate
+def test_messages_cancel():
+    responses.add(
+        responses.POST,
+        'https://api.courier.com/messages/id/cancel',
+        status=200,
+        content_type='application/json',
+        body='{}'
+    )
 
+    c = Courier(auth_token='123456789ABCDF')
+    r = c.messages.cancel(message_id="id")
 
-
+    assert r == {}

--- a/trycourier/messages.py
+++ b/trycourier/messages.py
@@ -112,3 +112,29 @@ class Messages():
             raise CourierAPIException(resp)
 
         return resp.json()
+
+    def cancel(self, message_id):
+        """
+        Cancel the message delivery.
+
+        Args:
+            message_id (str): A unique identifier associated with the message
+            you wish to retrieve (returned after each 'send()' call.
+            See
+            https://www.courier.com/docs/reference/send/message/#requestid-details
+            for details.)
+
+        Raises:
+            CourierAPIException: Any error returned by the Courier API
+
+        Returns:
+            dict: Contains message item
+        """
+        url = "%s/%s/cancel" % (self.uri, message_id)
+
+        resp = self.session.post(url)
+
+        if resp.status_code >= 400:
+            raise CourierAPIException(resp)
+
+        return resp.json()


### PR DESCRIPTION
## Description of the change
- add support for cancel message api as described in the Cancel Message API : https://www.courier.com/docs/reference/logs/cancel/

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 