### PR TITLE
ci: add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+name: Release Please
+
+# Opens (and keeps updated) a release PR whenever conventional commits land on
+# main, then tags a GitHub Release when that PR merges. The Release is what
+# triggers this repo's publish-* workflow.
+#
+# Added by hand rather than by `stlc build --rewrite-scaffold`: this repo was
+# scaffolded by the Stainless SaaS before stlc existed, so its scaffold has no
+# release workflow and stlc preserves that absence. stlc preserves hand-edits to
+# .github/workflows/, so this file survives future builds.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    # Guard against forks running this.
+    if: github.repository == 'trycourier/courier-python'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/release-please.yml`.

## Why

This repo already has `release-please-config.json` and `.release-please-manifest.json`, but no workflow to run release-please — the Stainless SaaS ran it externally through its GitHub App (`app/stainless-app` authored every `release: x.y.z` PR here). Now that SDK generation has moved to `stlc` in `trycourier/api-spec`, nothing triggers a release, so it has to run in-repo.

Without this, a merged SDK update lands on `main` but never opens a release PR and never publishes.

## What it does

On a push to `main`, release-please opens (or updates) a release PR from conventional commits, and on merge tags a GitHub Release — which is what this repo's existing `publish-*` workflow already listens for. Publishing itself is unchanged.

Added by hand rather than via `stlc build --rewrite-scaffold`: that path does not generate a release workflow for a repo the SaaS scaffolded pre-stlc, and on `courier-go` it also dropped the `test` job from `ci.yml`. stlc preserves hand-edits under `.github/workflows/`, so this file survives future builds.

`RELEASE_PLEASE_TOKEN` is already set on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
