### PR TITLE
docs: sync README from api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
 # Courier Python SDK
 
-The Courier Python SDK provides typed access to the Courier REST API from any Python 3.9+ application. It includes synchronous and asynchronous clients, Pydantic response models, TypedDict request params, and automatic retries.
+The Courier Python SDK provides typed access to the Courier REST API from Python applications. Use it to send notifications, manage user profiles, check message status, issue JWT tokens for client-side SDKs, and more.
 
 ## Installation
 
@@ -9,74 +8,31 @@ The Courier Python SDK provides typed access to the Courier REST API from any Py
 pip install trycourier
 ```
 
-Also available via `poetry add trycourier` and `pipenv install trycourier`.
+Requires Python 3.8+.
 
 ## Quick Start
 
 ```python
+import os
 from courier import Courier
 
-client = Courier()
+client = Courier(
+    api_key=os.environ.get("COURIER_API_KEY"),  # the default, can be omitted
+)
 
 response = client.send.message(
     message={
-        "to": {"email": "you@example.com"},
-        "content": {
-            "title": "Hello from Courier!",
-            "body": "Your first notification, sent with the Python SDK.",
-        },
+        "to": {"user_id": "your_user_id"},
+        "template": "your_template_id",
+        "data": {"foo": "bar"},
     },
 )
-
 print(response.request_id)
 ```
 
-The client reads `COURIER_API_KEY` from your environment automatically. You can also pass it explicitly: `Courier(api_key='your-key')`.
+The client reads `COURIER_API_KEY` from your environment automatically.
 
-### Async usage
-
-Import `AsyncCourier` instead of `Courier` and use `await`:
-
-```python
-import asyncio
-from courier import AsyncCourier
-
-client = AsyncCourier()
-
-async def main():
-    response = await client.send.message(
-        message={
-            "to": {"email": "you@example.com"},
-            "content": {
-                "title": "Hello from Courier!",
-                "body": "Sent from the async Python client.",
-            },
-        },
-    )
-    print(response.request_id)
-
-asyncio.run(main())
-```
-
-## Common Operations
-
-```python
-# Check message delivery status
-message = client.messages.retrieve("message-id")
-print(message.status)
-
-# Create or update a user profile
-client.profiles.create("user_123", profile={
-    "email": "jane@example.com",
-    "name": "Jane Doe",
-})
-
-# Issue a JWT for client-side SDK auth
-result = client.auth.issue_token(
-    scope="user_id:user_123 inbox:read:messages inbox:write:events",
-    expires_in="2 days",
-)
-```
+An async client is also available as `AsyncCourier`, with the same methods.
 
 ## Documentation
 
@@ -85,4 +41,3 @@ Full documentation: **[courier.com/docs/sdk-libraries/python](https://www.courie
 - [Quickstart](https://www.courier.com/docs/getting-started/quickstart/)
 - [Send API](https://www.courier.com/docs/platform/sending/send-message/)
 - [API Reference](https://www.courier.com/docs/reference/get-started/)
-<!-- AUTO-GENERATED-OVERVIEW:END -->


### PR DESCRIPTION
Takes ownership of this README in the SDK repo.

`trycourier/api-spec` used to overwrite it on every spec merge, from its own `READMEs/<target>.md` overlay. That overlay is being removed (trycourier/api-spec#200) — kits are now generated SDK source only, and `README.md` is pruned from them. This lands the api-spec copy here once so nothing is lost, and from now on **this repo owns its README**.

Two notes:

- The `AUTO-GENERATED-OVERVIEW` markers are dropped. They claimed the file was synced from mintlify-docs, but `mintlify-docs/sdk-libraries/readme-exports/readme-sync-map.json` targets only the web and mobile SDKs — never this repo. Nothing has been rewriting them, and the banner told maintainers not to edit a file they in fact own.
- Where the install snippet carries a version, it is wrapped in `x-release-please-start-version` markers so release-please keeps it current on each release (this repo already lists `README.md` in its `extra-files`).

Review the content as a normal docs change — if the previous version read better in places, keep those parts.