### PR TITLE
chore(api): regenerate SDK

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
-configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0
+configured_endpoints: 150

--- a/api.md
+++ b/api.md
@@ -294,6 +294,28 @@ Methods:
 - <code title="post /broadcasts/{broadcastId}/schedule">client.broadcasts.<a href="./src/courier/resources/broadcasts.py">schedule</a>(broadcast_id, \*\*<a href="src/courier/types/broadcast_schedule_params.py">params</a>) -> <a href="./src/courier/types/broadcast.py">Broadcast</a></code>
 - <code title="post /broadcasts/{broadcastId}/send">client.broadcasts.<a href="./src/courier/resources/broadcasts.py">send</a>(broadcast_id, \*\*<a href="src/courier/types/broadcast_send_params.py">params</a>) -> <a href="./src/courier/types/broadcast.py">Broadcast</a></code>
 
+# Bulk
+
+Types:
+
+```python
+from courier.types import (
+    InboundBulkMessage,
+    InboundBulkMessageUser,
+    BulkCreateJobResponse,
+    BulkListUsersResponse,
+    BulkRetrieveJobResponse,
+)
+```
+
+Methods:
+
+- <code title="post /bulk/{job_id}">client.bulk.<a href="./src/courier/resources/bulk.py">add_users</a>(job_id, \*\*<a href="src/courier/types/bulk_add_users_params.py">params</a>) -> None</code>
+- <code title="post /bulk">client.bulk.<a href="./src/courier/resources/bulk.py">create_job</a>(\*\*<a href="src/courier/types/bulk_create_job_params.py">params</a>) -> <a href="./src/courier/types/bulk_create_job_response.py">BulkCreateJobResponse</a></code>
+- <code title="get /bulk/{job_id}/users">client.bulk.<a href="./src/courier/resources/bulk.py">list_users</a>(job_id, \*\*<a href="src/courier/types/bulk_list_users_params.py">params</a>) -> <a href="./src/courier/types/bulk_list_users_response.py">BulkListUsersResponse</a></code>
+- <code title="get /bulk/{job_id}">client.bulk.<a href="./src/courier/resources/bulk.py">retrieve_job</a>(job_id) -> <a href="./src/courier/types/bulk_retrieve_job_response.py">BulkRetrieveJobResponse</a></code>
+- <code title="post /bulk/{job_id}/run">client.bulk.<a href="./src/courier/resources/bulk.py">run_job</a>(job_id) -> None</code>
+
 # Brands
 
 Types:

--- a/src/courier/_client.py
+++ b/src/courier/_client.py
@@ -37,6 +37,7 @@ from ._base_client import (
 if TYPE_CHECKING:
     from .resources import (
         auth,
+        bulk,
         send,
         lists,
         users,
@@ -59,6 +60,7 @@ if TYPE_CHECKING:
         workspace_preferences,
     )
     from .resources.auth import AuthResource, AsyncAuthResource
+    from .resources.bulk import BulkResource, AsyncBulkResource
     from .resources.send import SendResource, AsyncSendResource
     from .resources.brands import BrandsResource, AsyncBrandsResource
     from .resources.inbound import InboundResource, AsyncInboundResource
@@ -219,6 +221,12 @@ class Courier(SyncAPIClient):
         from .resources.broadcasts import BroadcastsResource
 
         return BroadcastsResource(self)
+
+    @cached_property
+    def bulk(self) -> BulkResource:
+        from .resources.bulk import BulkResource
+
+        return BulkResource(self)
 
     @cached_property
     def brands(self) -> BrandsResource:
@@ -579,6 +587,12 @@ class AsyncCourier(AsyncAPIClient):
         return AsyncBroadcastsResource(self)
 
     @cached_property
+    def bulk(self) -> AsyncBulkResource:
+        from .resources.bulk import AsyncBulkResource
+
+        return AsyncBulkResource(self)
+
+    @cached_property
     def brands(self) -> AsyncBrandsResource:
         """
         Manage the logos, colors, and layout that give the templates you send a consistent look.
@@ -879,6 +893,12 @@ class CourierWithRawResponse:
         return BroadcastsResourceWithRawResponse(self._client.broadcasts)
 
     @cached_property
+    def bulk(self) -> bulk.BulkResourceWithRawResponse:
+        from .resources.bulk import BulkResourceWithRawResponse
+
+        return BulkResourceWithRawResponse(self._client.bulk)
+
+    @cached_property
     def brands(self) -> brands.BrandsResourceWithRawResponse:
         """
         Manage the logos, colors, and layout that give the templates you send a consistent look.
@@ -1065,6 +1085,12 @@ class AsyncCourierWithRawResponse:
         from .resources.broadcasts import AsyncBroadcastsResourceWithRawResponse
 
         return AsyncBroadcastsResourceWithRawResponse(self._client.broadcasts)
+
+    @cached_property
+    def bulk(self) -> bulk.AsyncBulkResourceWithRawResponse:
+        from .resources.bulk import AsyncBulkResourceWithRawResponse
+
+        return AsyncBulkResourceWithRawResponse(self._client.bulk)
 
     @cached_property
     def brands(self) -> brands.AsyncBrandsResourceWithRawResponse:
@@ -1255,6 +1281,12 @@ class CourierWithStreamedResponse:
         return BroadcastsResourceWithStreamingResponse(self._client.broadcasts)
 
     @cached_property
+    def bulk(self) -> bulk.BulkResourceWithStreamingResponse:
+        from .resources.bulk import BulkResourceWithStreamingResponse
+
+        return BulkResourceWithStreamingResponse(self._client.bulk)
+
+    @cached_property
     def brands(self) -> brands.BrandsResourceWithStreamingResponse:
         """
         Manage the logos, colors, and layout that give the templates you send a consistent look.
@@ -1441,6 +1473,12 @@ class AsyncCourierWithStreamedResponse:
         from .resources.broadcasts import AsyncBroadcastsResourceWithStreamingResponse
 
         return AsyncBroadcastsResourceWithStreamingResponse(self._client.broadcasts)
+
+    @cached_property
+    def bulk(self) -> bulk.AsyncBulkResourceWithStreamingResponse:
+        from .resources.bulk import AsyncBulkResourceWithStreamingResponse
+
+        return AsyncBulkResourceWithStreamingResponse(self._client.bulk)
 
     @cached_property
     def brands(self) -> brands.AsyncBrandsResourceWithStreamingResponse:

--- a/src/courier/resources/__init__.py
+++ b/src/courier/resources/__init__.py
@@ -8,6 +8,14 @@ from .auth import (
     AuthResourceWithStreamingResponse,
     AsyncAuthResourceWithStreamingResponse,
 )
+from .bulk import (
+    BulkResource,
+    AsyncBulkResource,
+    BulkResourceWithRawResponse,
+    AsyncBulkResourceWithRawResponse,
+    BulkResourceWithStreamingResponse,
+    AsyncBulkResourceWithStreamingResponse,
+)
 from .send import (
     SendResource,
     AsyncSendResource,
@@ -218,6 +226,12 @@ __all__ = [
     "AsyncBroadcastsResourceWithRawResponse",
     "BroadcastsResourceWithStreamingResponse",
     "AsyncBroadcastsResourceWithStreamingResponse",
+    "BulkResource",
+    "AsyncBulkResource",
+    "BulkResourceWithRawResponse",
+    "AsyncBulkResourceWithRawResponse",
+    "BulkResourceWithStreamingResponse",
+    "AsyncBulkResourceWithStreamingResponse",
     "BrandsResource",
     "AsyncBrandsResource",
     "BrandsResourceWithRawResponse",

--- a/src/courier/resources/bulk.py
+++ b/src/courier/resources/bulk.py
@@ -1,0 +1,539 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import httpx
+
+from ..types import bulk_add_users_params, bulk_create_job_params, bulk_list_users_params
+from .._types import Body, Omit, Query, Headers, NoneType, NotGiven, omit, not_given
+from .._utils import path_template, maybe_transform, async_maybe_transform
+from .._compat import cached_property
+from .._resource import SyncAPIResource, AsyncAPIResource
+from .._response import (
+    to_raw_response_wrapper,
+    to_streamed_response_wrapper,
+    async_to_raw_response_wrapper,
+    async_to_streamed_response_wrapper,
+)
+from .._base_client import make_request_options
+from ..types.bulk_create_job_response import BulkCreateJobResponse
+from ..types.bulk_list_users_response import BulkListUsersResponse
+from ..types.bulk_retrieve_job_response import BulkRetrieveJobResponse
+from ..types.inbound_bulk_message_param import InboundBulkMessageParam
+from ..types.inbound_bulk_message_user_param import InboundBulkMessageUserParam
+
+__all__ = ["BulkResource", "AsyncBulkResource"]
+
+
+class BulkResource(SyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> BulkResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/trycourier/courier-python#accessing-raw-response-data-eg-headers
+        """
+        return BulkResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> BulkResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/trycourier/courier-python#with_streaming_response
+        """
+        return BulkResourceWithStreamingResponse(self)
+
+    def add_users(
+        self,
+        job_id: str,
+        *,
+        users: Iterable[InboundBulkMessageUserParam],
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> None:
+        """
+        Ingest user data into a Bulk Job.
+
+        **Important**: For email-based bulk jobs, each user must include `profile.email`
+        for provider routing to work correctly. The `to.email` field is not sufficient
+        for email provider routing.
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        return self._post(
+            path_template("/bulk/{job_id}", job_id=job_id),
+            body=maybe_transform({"users": users}, bulk_add_users_params.BulkAddUsersParams),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+    def create_job(
+        self,
+        *,
+        message: InboundBulkMessageParam,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkCreateJobResponse:
+        """
+        Creates a new bulk job for sending messages to multiple recipients.
+
+        **Required**: `message.event` (event ID or notification ID)
+
+        **Optional (V2 format)**: `message.template` (notification ID) or
+        `message.content` (Elemental content) can be provided to override the
+        notification associated with the event.
+
+        Args:
+          message:
+              Bulk message definition. Supports two formats:
+
+              - V1 format: Requires `event` field (event ID or notification ID)
+              - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+                content) in addition to `event`
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        return self._post(
+            "/bulk",
+            body=maybe_transform({"message": message}, bulk_create_job_params.BulkCreateJobParams),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=BulkCreateJobResponse,
+        )
+
+    def list_users(
+        self,
+        job_id: str,
+        *,
+        cursor: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkListUsersResponse:
+        """
+        Get Bulk Job Users
+
+        Args:
+          cursor: A unique identifier that allows for fetching the next set of users added to the
+              bulk job
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        return self._get(
+            path_template("/bulk/{job_id}/users", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=maybe_transform({"cursor": cursor}, bulk_list_users_params.BulkListUsersParams),
+            ),
+            cast_to=BulkListUsersResponse,
+        )
+
+    def retrieve_job(
+        self,
+        job_id: str,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkRetrieveJobResponse:
+        """
+        Get a bulk job
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        return self._get(
+            path_template("/bulk/{job_id}", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=BulkRetrieveJobResponse,
+        )
+
+    def run_job(
+        self,
+        job_id: str,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> None:
+        """
+        Run a bulk job
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        return self._post(
+            path_template("/bulk/{job_id}/run", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+
+class AsyncBulkResource(AsyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> AsyncBulkResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/trycourier/courier-python#accessing-raw-response-data-eg-headers
+        """
+        return AsyncBulkResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> AsyncBulkResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/trycourier/courier-python#with_streaming_response
+        """
+        return AsyncBulkResourceWithStreamingResponse(self)
+
+    async def add_users(
+        self,
+        job_id: str,
+        *,
+        users: Iterable[InboundBulkMessageUserParam],
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> None:
+        """
+        Ingest user data into a Bulk Job.
+
+        **Important**: For email-based bulk jobs, each user must include `profile.email`
+        for provider routing to work correctly. The `to.email` field is not sufficient
+        for email provider routing.
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        return await self._post(
+            path_template("/bulk/{job_id}", job_id=job_id),
+            body=await async_maybe_transform({"users": users}, bulk_add_users_params.BulkAddUsersParams),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+    async def create_job(
+        self,
+        *,
+        message: InboundBulkMessageParam,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkCreateJobResponse:
+        """
+        Creates a new bulk job for sending messages to multiple recipients.
+
+        **Required**: `message.event` (event ID or notification ID)
+
+        **Optional (V2 format)**: `message.template` (notification ID) or
+        `message.content` (Elemental content) can be provided to override the
+        notification associated with the event.
+
+        Args:
+          message:
+              Bulk message definition. Supports two formats:
+
+              - V1 format: Requires `event` field (event ID or notification ID)
+              - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+                content) in addition to `event`
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        return await self._post(
+            "/bulk",
+            body=await async_maybe_transform({"message": message}, bulk_create_job_params.BulkCreateJobParams),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=BulkCreateJobResponse,
+        )
+
+    async def list_users(
+        self,
+        job_id: str,
+        *,
+        cursor: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkListUsersResponse:
+        """
+        Get Bulk Job Users
+
+        Args:
+          cursor: A unique identifier that allows for fetching the next set of users added to the
+              bulk job
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        return await self._get(
+            path_template("/bulk/{job_id}/users", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=await async_maybe_transform({"cursor": cursor}, bulk_list_users_params.BulkListUsersParams),
+            ),
+            cast_to=BulkListUsersResponse,
+        )
+
+    async def retrieve_job(
+        self,
+        job_id: str,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> BulkRetrieveJobResponse:
+        """
+        Get a bulk job
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        return await self._get(
+            path_template("/bulk/{job_id}", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=BulkRetrieveJobResponse,
+        )
+
+    async def run_job(
+        self,
+        job_id: str,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> None:
+        """
+        Run a bulk job
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        return await self._post(
+            path_template("/bulk/{job_id}/run", job_id=job_id),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+
+class BulkResourceWithRawResponse:
+    def __init__(self, bulk: BulkResource) -> None:
+        self._bulk = bulk
+
+        self.add_users = to_raw_response_wrapper(
+            bulk.add_users,
+        )
+        self.create_job = to_raw_response_wrapper(
+            bulk.create_job,
+        )
+        self.list_users = to_raw_response_wrapper(
+            bulk.list_users,
+        )
+        self.retrieve_job = to_raw_response_wrapper(
+            bulk.retrieve_job,
+        )
+        self.run_job = to_raw_response_wrapper(
+            bulk.run_job,
+        )
+
+
+class AsyncBulkResourceWithRawResponse:
+    def __init__(self, bulk: AsyncBulkResource) -> None:
+        self._bulk = bulk
+
+        self.add_users = async_to_raw_response_wrapper(
+            bulk.add_users,
+        )
+        self.create_job = async_to_raw_response_wrapper(
+            bulk.create_job,
+        )
+        self.list_users = async_to_raw_response_wrapper(
+            bulk.list_users,
+        )
+        self.retrieve_job = async_to_raw_response_wrapper(
+            bulk.retrieve_job,
+        )
+        self.run_job = async_to_raw_response_wrapper(
+            bulk.run_job,
+        )
+
+
+class BulkResourceWithStreamingResponse:
+    def __init__(self, bulk: BulkResource) -> None:
+        self._bulk = bulk
+
+        self.add_users = to_streamed_response_wrapper(
+            bulk.add_users,
+        )
+        self.create_job = to_streamed_response_wrapper(
+            bulk.create_job,
+        )
+        self.list_users = to_streamed_response_wrapper(
+            bulk.list_users,
+        )
+        self.retrieve_job = to_streamed_response_wrapper(
+            bulk.retrieve_job,
+        )
+        self.run_job = to_streamed_response_wrapper(
+            bulk.run_job,
+        )
+
+
+class AsyncBulkResourceWithStreamingResponse:
+    def __init__(self, bulk: AsyncBulkResource) -> None:
+        self._bulk = bulk
+
+        self.add_users = async_to_streamed_response_wrapper(
+            bulk.add_users,
+        )
+        self.create_job = async_to_streamed_response_wrapper(
+            bulk.create_job,
+        )
+        self.list_users = async_to_streamed_response_wrapper(
+            bulk.list_users,
+        )
+        self.retrieve_job = async_to_streamed_response_wrapper(
+            bulk.retrieve_job,
+        )
+        self.run_job = async_to_streamed_response_wrapper(
+            bulk.run_job,
+        )

--- a/src/courier/resources/send.py
+++ b/src/courier/resources/send.py
@@ -61,7 +61,8 @@ class SendResource(SyncAPIResource):
         """Sends a message to one or more recipients and returns a requestId.
 
         Courier
-        routes it to email, SMS, push, chat, or in-app based on your rules.
+        routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+        returned requestId to look up delivery status via the Messages API.
 
         Args:
           message: The message property has the following primary top-level properties. They define
@@ -134,7 +135,8 @@ class AsyncSendResource(AsyncAPIResource):
         """Sends a message to one or more recipients and returns a requestId.
 
         Courier
-        routes it to email, SMS, push, chat, or in-app based on your rules.
+        routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+        returned requestId to look up delivery status via the Messages API.
 
         Args:
           message: The message property has the following primary top-level properties. They define

--- a/src/courier/types/__init__.py
+++ b/src/courier/types/__init__.py
@@ -155,6 +155,7 @@ from .brand_settings_email import BrandSettingsEmail as BrandSettingsEmail
 from .brand_settings_param import BrandSettingsParam as BrandSettingsParam
 from .brand_snippets_param import BrandSnippetsParam as BrandSnippetsParam
 from .brand_template_param import BrandTemplateParam as BrandTemplateParam
+from .inbound_bulk_message import InboundBulkMessage as InboundBulkMessage
 from .journey_version_item import JourneyVersionItem as JourneyVersionItem
 from .provider_list_params import ProviderListParams as ProviderListParams
 from .tenant_list_response import TenantListResponse as TenantListResponse
@@ -162,6 +163,7 @@ from .tenant_update_params import TenantUpdateParams as TenantUpdateParams
 from .brand_settings_in_app import BrandSettingsInApp as BrandSettingsInApp
 from .broadcast_list_params import BroadcastListParams as BroadcastListParams
 from .broadcast_send_params import BroadcastSendParams as BroadcastSendParams
+from .bulk_add_users_params import BulkAddUsersParams as BulkAddUsersParams
 from .journey_ai_node_param import JourneyAINodeParam as JourneyAINodeParam
 from .journey_cancel_params import JourneyCancelParams as JourneyCancelParams
 from .journey_create_params import JourneyCreateParams as JourneyCreateParams
@@ -173,6 +175,8 @@ from .send_message_response import SendMessageResponse as SendMessageResponse
 from .audience_list_response import AudienceListResponse as AudienceListResponse
 from .audience_update_params import AudienceUpdateParams as AudienceUpdateParams
 from .automation_list_params import AutomationListParams as AutomationListParams
+from .bulk_create_job_params import BulkCreateJobParams as BulkCreateJobParams
+from .bulk_list_users_params import BulkListUsersParams as BulkListUsersParams
 from .element_with_checksums import ElementWithChecksums as ElementWithChecksums
 from .journey_condition_atom import JourneyConditionAtom as JourneyConditionAtom
 from .journey_merge_strategy import JourneyMergeStrategy as JourneyMergeStrategy
@@ -200,6 +204,8 @@ from .profile_create_response import ProfileCreateResponse as ProfileCreateRespo
 from .providers_catalog_entry import ProvidersCatalogEntry as ProvidersCatalogEntry
 from .widget_background_param import WidgetBackgroundParam as WidgetBackgroundParam
 from .audience_update_response import AudienceUpdateResponse as AudienceUpdateResponse
+from .bulk_create_job_response import BulkCreateJobResponse as BulkCreateJobResponse
+from .bulk_list_users_response import BulkListUsersResponse as BulkListUsersResponse
 from .journey_conditions_field import JourneyConditionsField as JourneyConditionsField
 from .journey_delay_until_node import JourneyDelayUntilNode as JourneyDelayUntilNode
 from .journey_experiment_param import JourneyExperimentParam as JourneyExperimentParam
@@ -217,11 +223,14 @@ from .audit_event_list_response import AuditEventListResponse as AuditEventListR
 from .auth_issue_token_response import AuthIssueTokenResponse as AuthIssueTokenResponse
 from .broadcast_schedule_params import BroadcastScheduleParams as BroadcastScheduleParams
 from .default_preferences_param import DefaultPreferencesParam as DefaultPreferencesParam
+from .inbound_bulk_message_user import InboundBulkMessageUser as InboundBulkMessageUser
 from .message_retrieve_response import MessageRetrieveResponse as MessageRetrieveResponse
 from .profile_retrieve_response import ProfileRetrieveResponse as ProfileRetrieveResponse
 from .translation_update_params import TranslationUpdateParams as TranslationUpdateParams
 from .automation_invoke_response import AutomationInvokeResponse as AutomationInvokeResponse
 from .brand_settings_email_param import BrandSettingsEmailParam as BrandSettingsEmailParam
+from .bulk_retrieve_job_response import BulkRetrieveJobResponse as BulkRetrieveJobResponse
+from .inbound_bulk_message_param import InboundBulkMessageParam as InboundBulkMessageParam
 from .inbound_track_event_params import InboundTrackEventParams as InboundTrackEventParams
 from .journey_experiment_variant import JourneyExperimentVariant as JourneyExperimentVariant
 from .notification_create_params import NotificationCreateParams as NotificationCreateParams
@@ -266,6 +275,7 @@ from .notification_put_locale_params import NotificationPutLocaleParams as Notif
 from .notification_template_response import NotificationTemplateResponse as NotificationTemplateResponse
 from .routing_strategy_create_params import RoutingStrategyCreateParams as RoutingStrategyCreateParams
 from .routing_strategy_list_response import RoutingStrategyListResponse as RoutingStrategyListResponse
+from .inbound_bulk_message_user_param import InboundBulkMessageUserParam as InboundBulkMessageUserParam
 from .journey_api_invoke_trigger_node import JourneyAPIInvokeTriggerNode as JourneyAPIInvokeTriggerNode
 from .notification_put_content_params import NotificationPutContentParams as NotificationPutContentParams
 from .notification_put_element_params import NotificationPutElementParams as NotificationPutElementParams

--- a/src/courier/types/bulk_add_users_params.py
+++ b/src/courier/types/bulk_add_users_params.py
@@ -1,0 +1,14 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Iterable
+from typing_extensions import Required, TypedDict
+
+from .inbound_bulk_message_user_param import InboundBulkMessageUserParam
+
+__all__ = ["BulkAddUsersParams"]
+
+
+class BulkAddUsersParams(TypedDict, total=False):
+    users: Required[Iterable[InboundBulkMessageUserParam]]

--- a/src/courier/types/bulk_create_job_params.py
+++ b/src/courier/types/bulk_create_job_params.py
@@ -1,0 +1,19 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Required, TypedDict
+
+from .inbound_bulk_message_param import InboundBulkMessageParam
+
+__all__ = ["BulkCreateJobParams"]
+
+
+class BulkCreateJobParams(TypedDict, total=False):
+    message: Required[InboundBulkMessageParam]
+    """Bulk message definition. Supports two formats:
+
+    - V1 format: Requires `event` field (event ID or notification ID)
+    - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+      content) in addition to `event`
+    """

--- a/src/courier/types/bulk_create_job_response.py
+++ b/src/courier/types/bulk_create_job_response.py
@@ -1,0 +1,11 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from pydantic import Field as FieldInfo
+
+from .._models import BaseModel
+
+__all__ = ["BulkCreateJobResponse"]
+
+
+class BulkCreateJobResponse(BaseModel):
+    job_id: str = FieldInfo(alias="jobId")

--- a/src/courier/types/bulk_list_users_params.py
+++ b/src/courier/types/bulk_list_users_params.py
@@ -1,0 +1,16 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import TypedDict
+
+__all__ = ["BulkListUsersParams"]
+
+
+class BulkListUsersParams(TypedDict, total=False):
+    cursor: Optional[str]
+    """
+    A unique identifier that allows for fetching the next set of users added to the
+    bulk job
+    """

--- a/src/courier/types/bulk_list_users_response.py
+++ b/src/courier/types/bulk_list_users_response.py
@@ -1,0 +1,24 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import List, Optional
+from typing_extensions import Literal
+
+from pydantic import Field as FieldInfo
+
+from .._models import BaseModel
+from .shared.paging import Paging
+from .inbound_bulk_message_user import InboundBulkMessageUser
+
+__all__ = ["BulkListUsersResponse", "Item"]
+
+
+class Item(InboundBulkMessageUser):
+    status: Literal["PENDING", "ENQUEUED", "ERROR"]
+
+    message_id: Optional[str] = FieldInfo(alias="messageId", default=None)
+
+
+class BulkListUsersResponse(BaseModel):
+    items: List[Item]
+
+    paging: Paging

--- a/src/courier/types/bulk_retrieve_job_response.py
+++ b/src/courier/types/bulk_retrieve_job_response.py
@@ -1,0 +1,30 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing_extensions import Literal
+
+from .._models import BaseModel
+from .inbound_bulk_message import InboundBulkMessage
+
+__all__ = ["BulkRetrieveJobResponse", "Job"]
+
+
+class Job(BaseModel):
+    definition: InboundBulkMessage
+    """Bulk message definition. Supports two formats:
+
+    - V1 format: Requires `event` field (event ID or notification ID)
+    - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+      content) in addition to `event`
+    """
+
+    enqueued: int
+
+    failures: int
+
+    received: int
+
+    status: Literal["CREATED", "PROCESSING", "COMPLETED", "ERROR"]
+
+
+class BulkRetrieveJobResponse(BaseModel):
+    job: Job

--- a/src/courier/types/inbound_bulk_message.py
+++ b/src/courier/types/inbound_bulk_message.py
@@ -1,0 +1,50 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Dict, Union, Optional
+from typing_extensions import TypeAlias
+
+from .._models import BaseModel
+from .shared.elemental_content import ElementalContent
+from .shared.elemental_content_sugar import ElementalContentSugar
+
+__all__ = ["InboundBulkMessage", "Content"]
+
+Content: TypeAlias = Union[ElementalContentSugar, ElementalContent, None]
+
+
+class InboundBulkMessage(BaseModel):
+    """Bulk message definition.
+
+    Supports two formats:
+    - V1 format: Requires `event` field (event ID or notification ID)
+    - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+    """
+
+    event: str
+    """Event ID or Notification ID (required).
+
+    Can be either a Notification ID (e.g., "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a
+    custom Event ID (e.g., "welcome-email") mapped to a notification.
+    """
+
+    brand: Optional[str] = None
+
+    content: Optional[Content] = None
+    """Elemental content (optional, for V2 format).
+
+    When provided, this will be used instead of the notification associated with the
+    `event` field.
+    """
+
+    data: Optional[Dict[str, object]] = None
+
+    locale: Optional[Dict[str, Dict[str, object]]] = None
+
+    override: Optional[Dict[str, object]] = None
+
+    template: Optional[str] = None
+    """Notification ID or template ID (optional, for V2 format).
+
+    When provided, this will be used instead of the notification associated with the
+    `event` field.
+    """

--- a/src/courier/types/inbound_bulk_message_param.py
+++ b/src/courier/types/inbound_bulk_message_param.py
@@ -1,0 +1,51 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Optional
+from typing_extensions import Required, TypeAlias, TypedDict
+
+from .shared_params.elemental_content import ElementalContent
+from .shared_params.elemental_content_sugar import ElementalContentSugar
+
+__all__ = ["InboundBulkMessageParam", "Content"]
+
+Content: TypeAlias = Union[ElementalContentSugar, ElementalContent]
+
+
+class InboundBulkMessageParam(TypedDict, total=False):
+    """Bulk message definition.
+
+    Supports two formats:
+    - V1 format: Requires `event` field (event ID or notification ID)
+    - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+    """
+
+    event: Required[str]
+    """Event ID or Notification ID (required).
+
+    Can be either a Notification ID (e.g., "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a
+    custom Event ID (e.g., "welcome-email") mapped to a notification.
+    """
+
+    brand: Optional[str]
+
+    content: Optional[Content]
+    """Elemental content (optional, for V2 format).
+
+    When provided, this will be used instead of the notification associated with the
+    `event` field.
+    """
+
+    data: Optional[Dict[str, object]]
+
+    locale: Optional[Dict[str, Dict[str, object]]]
+
+    override: Optional[Dict[str, object]]
+
+    template: Optional[str]
+    """Notification ID or template ID (optional, for V2 format).
+
+    When provided, this will be used instead of the notification associated with the
+    `event` field.
+    """

--- a/src/courier/types/inbound_bulk_message_user.py
+++ b/src/courier/types/inbound_bulk_message_user.py
@@ -1,0 +1,34 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Dict, Optional
+
+from .._models import BaseModel
+from .shared.user_recipient import UserRecipient
+from .shared.recipient_preferences import RecipientPreferences
+
+__all__ = ["InboundBulkMessageUser"]
+
+
+class InboundBulkMessageUser(BaseModel):
+    data: Optional[object] = None
+    """User-specific data that will be merged with message.data"""
+
+    preferences: Optional[RecipientPreferences] = None
+
+    profile: Optional[Dict[str, object]] = None
+    """User profile information.
+
+    For email-based bulk jobs, `profile.email` is required for provider routing to
+    determine if the message can be delivered. The email address should be provided
+    here rather than in `to.email`.
+    """
+
+    recipient: Optional[str] = None
+    """User ID (legacy field, use profile or to.user_id instead)"""
+
+    to: Optional[UserRecipient] = None
+    """Optional recipient information.
+
+    Note: For email provider routing, use `profile.email` instead of `to.email`. The
+    `to` field is primarily used for recipient identification and data merging.
+    """

--- a/src/courier/types/inbound_bulk_message_user_param.py
+++ b/src/courier/types/inbound_bulk_message_user_param.py
@@ -1,0 +1,36 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from typing_extensions import TypedDict
+
+from .shared_params.user_recipient import UserRecipient
+from .shared_params.recipient_preferences import RecipientPreferences
+
+__all__ = ["InboundBulkMessageUserParam"]
+
+
+class InboundBulkMessageUserParam(TypedDict, total=False):
+    data: object
+    """User-specific data that will be merged with message.data"""
+
+    preferences: Optional[RecipientPreferences]
+
+    profile: Optional[Dict[str, object]]
+    """User profile information.
+
+    For email-based bulk jobs, `profile.email` is required for provider routing to
+    determine if the message can be delivered. The email address should be provided
+    here rather than in `to.email`.
+    """
+
+    recipient: Optional[str]
+    """User ID (legacy field, use profile or to.user_id instead)"""
+
+    to: Optional[UserRecipient]
+    """Optional recipient information.
+
+    Note: For email provider routing, use `profile.email` instead of `to.email`. The
+    `to` field is primarily used for recipient identification and data merging.
+    """

--- a/tests/api_resources/test_bulk.py
+++ b/tests/api_resources/test_bulk.py
@@ -1,0 +1,496 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import pytest
+
+from courier import Courier, AsyncCourier
+from tests.utils import assert_matches_type
+from courier.types import (
+    BulkCreateJobResponse,
+    BulkListUsersResponse,
+    BulkRetrieveJobResponse,
+)
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class TestBulk:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_add_users(self, client: Courier) -> None:
+        bulk = client.bulk.add_users(
+            job_id="job_id",
+            users=[{}],
+        )
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_add_users(self, client: Courier) -> None:
+        response = client.bulk.with_raw_response.add_users(
+            job_id="job_id",
+            users=[{}],
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = response.parse()
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_add_users(self, client: Courier) -> None:
+        with client.bulk.with_streaming_response.add_users(
+            job_id="job_id",
+            users=[{}],
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = response.parse()
+            assert bulk is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_add_users(self, client: Courier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            client.bulk.with_raw_response.add_users(
+                job_id="",
+                users=[{}],
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_create_job(self, client: Courier) -> None:
+        bulk = client.bulk.create_job(
+            message={"event": "event"},
+        )
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_create_job_with_all_params(self, client: Courier) -> None:
+        bulk = client.bulk.create_job(
+            message={
+                "event": "event",
+                "brand": "brand",
+                "content": {
+                    "body": "body",
+                    "title": "title",
+                },
+                "data": {"foo": "bar"},
+                "locale": {"foo": {"foo": "bar"}},
+                "override": {"foo": "bar"},
+                "template": "template",
+            },
+        )
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_create_job(self, client: Courier) -> None:
+        response = client.bulk.with_raw_response.create_job(
+            message={"event": "event"},
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = response.parse()
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_create_job(self, client: Courier) -> None:
+        with client.bulk.with_streaming_response.create_job(
+            message={"event": "event"},
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = response.parse()
+            assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_list_users(self, client: Courier) -> None:
+        bulk = client.bulk.list_users(
+            job_id="job_id",
+        )
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_list_users_with_all_params(self, client: Courier) -> None:
+        bulk = client.bulk.list_users(
+            job_id="job_id",
+            cursor="cursor",
+        )
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_list_users(self, client: Courier) -> None:
+        response = client.bulk.with_raw_response.list_users(
+            job_id="job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = response.parse()
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_list_users(self, client: Courier) -> None:
+        with client.bulk.with_streaming_response.list_users(
+            job_id="job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = response.parse()
+            assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_list_users(self, client: Courier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            client.bulk.with_raw_response.list_users(
+                job_id="",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_retrieve_job(self, client: Courier) -> None:
+        bulk = client.bulk.retrieve_job(
+            "job_id",
+        )
+        assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_retrieve_job(self, client: Courier) -> None:
+        response = client.bulk.with_raw_response.retrieve_job(
+            "job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = response.parse()
+        assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_retrieve_job(self, client: Courier) -> None:
+        with client.bulk.with_streaming_response.retrieve_job(
+            "job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = response.parse()
+            assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_retrieve_job(self, client: Courier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            client.bulk.with_raw_response.retrieve_job(
+                "",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_run_job(self, client: Courier) -> None:
+        bulk = client.bulk.run_job(
+            "job_id",
+        )
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_run_job(self, client: Courier) -> None:
+        response = client.bulk.with_raw_response.run_job(
+            "job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = response.parse()
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_run_job(self, client: Courier) -> None:
+        with client.bulk.with_streaming_response.run_job(
+            "job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = response.parse()
+            assert bulk is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_run_job(self, client: Courier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            client.bulk.with_raw_response.run_job(
+                "",
+            )
+
+
+class TestAsyncBulk:
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_add_users(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.add_users(
+            job_id="job_id",
+            users=[{}],
+        )
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_add_users(self, async_client: AsyncCourier) -> None:
+        response = await async_client.bulk.with_raw_response.add_users(
+            job_id="job_id",
+            users=[{}],
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = await response.parse()
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_add_users(self, async_client: AsyncCourier) -> None:
+        async with async_client.bulk.with_streaming_response.add_users(
+            job_id="job_id",
+            users=[{}],
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = await response.parse()
+            assert bulk is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_add_users(self, async_client: AsyncCourier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            await async_client.bulk.with_raw_response.add_users(
+                job_id="",
+                users=[{}],
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_create_job(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.create_job(
+            message={"event": "event"},
+        )
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_create_job_with_all_params(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.create_job(
+            message={
+                "event": "event",
+                "brand": "brand",
+                "content": {
+                    "body": "body",
+                    "title": "title",
+                },
+                "data": {"foo": "bar"},
+                "locale": {"foo": {"foo": "bar"}},
+                "override": {"foo": "bar"},
+                "template": "template",
+            },
+        )
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_create_job(self, async_client: AsyncCourier) -> None:
+        response = await async_client.bulk.with_raw_response.create_job(
+            message={"event": "event"},
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = await response.parse()
+        assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_create_job(self, async_client: AsyncCourier) -> None:
+        async with async_client.bulk.with_streaming_response.create_job(
+            message={"event": "event"},
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = await response.parse()
+            assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_list_users(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.list_users(
+            job_id="job_id",
+        )
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_list_users_with_all_params(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.list_users(
+            job_id="job_id",
+            cursor="cursor",
+        )
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_list_users(self, async_client: AsyncCourier) -> None:
+        response = await async_client.bulk.with_raw_response.list_users(
+            job_id="job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = await response.parse()
+        assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_list_users(self, async_client: AsyncCourier) -> None:
+        async with async_client.bulk.with_streaming_response.list_users(
+            job_id="job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = await response.parse()
+            assert_matches_type(BulkListUsersResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_list_users(self, async_client: AsyncCourier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            await async_client.bulk.with_raw_response.list_users(
+                job_id="",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_retrieve_job(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.retrieve_job(
+            "job_id",
+        )
+        assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_retrieve_job(self, async_client: AsyncCourier) -> None:
+        response = await async_client.bulk.with_raw_response.retrieve_job(
+            "job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = await response.parse()
+        assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_retrieve_job(self, async_client: AsyncCourier) -> None:
+        async with async_client.bulk.with_streaming_response.retrieve_job(
+            "job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = await response.parse()
+            assert_matches_type(BulkRetrieveJobResponse, bulk, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_retrieve_job(self, async_client: AsyncCourier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            await async_client.bulk.with_raw_response.retrieve_job(
+                "",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_run_job(self, async_client: AsyncCourier) -> None:
+        bulk = await async_client.bulk.run_job(
+            "job_id",
+        )
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_run_job(self, async_client: AsyncCourier) -> None:
+        response = await async_client.bulk.with_raw_response.run_job(
+            "job_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        bulk = await response.parse()
+        assert bulk is None
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_run_job(self, async_client: AsyncCourier) -> None:
+        async with async_client.bulk.with_streaming_response.run_job(
+            "job_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            bulk = await response.parse()
+            assert bulk is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_run_job(self, async_client: AsyncCourier) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `job_id` but received ''"):
+            await async_client.bulk.with_raw_response.run_job(
+                "",
+            )


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

18 files changed, 1409 insertions(+), 6 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                           |   5 +-
 api.md                                               |  22 ++
 src/courier/_client.py                               |  38 +++
 src/courier/resources/__init__.py                    |  14 +
 src/courier/resources/bulk.py                        | 539 +++++++++++++++++++++++++++++++++++++++
 src/courier/resources/send.py                        |   6 +-
 src/courier/types/__init__.py                        |  10 +
 src/courier/types/bulk_add_users_params.py           |  14 +
 src/courier/types/bulk_create_job_params.py          |  19 ++
 src/courier/types/bulk_create_job_response.py        |  11 +
 src/courier/types/bulk_list_users_params.py          |  16 ++
 src/courier/types/bulk_list_users_response.py        |  24 ++
 src/courier/types/bulk_retrieve_job_response.py      |  30 +++
 src/courier/types/inbound_bulk_message.py            |  50 ++++
 src/courier/types/inbound_bulk_message_param.py      |  51 ++++
 src/courier/types/inbound_bulk_message_user.py       |  34 +++
 src/courier/types/inbound_bulk_message_user_param.py |  36 +++
 tests/api_resources/test_bulk.py                     | 496 +++++++++++++++++++++++++++++++++++
 18 files changed, 1409 insertions(+), 6 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
