### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/tests/api_resources/automations/test_invoke.py
+++ b/tests/api_resources/automations/test_invoke.py
@@ -88,7 +88,7 @@ class TestInvoke:
     def test_method_invoke_by_template(self, client: Courier) -> None:
         invoke = client.automations.invoke.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         )
         assert_matches_type(AutomationInvokeResponse, invoke, path=["response"])
 
@@ -97,10 +97,10 @@ class TestInvoke:
     def test_method_invoke_by_template_with_all_params(self, client: Courier) -> None:
         invoke = client.automations.invoke.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
             brand="brand",
-            data={"foo": "bar"},
-            profile={"foo": "bar"},
+            data={"orderId": "bar"},
+            profile={"email": "bar"},
             template="template",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
@@ -112,7 +112,7 @@ class TestInvoke:
     def test_raw_response_invoke_by_template(self, client: Courier) -> None:
         response = client.automations.invoke.with_raw_response.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         )
 
         assert response.is_closed is True
@@ -125,7 +125,7 @@ class TestInvoke:
     def test_streaming_response_invoke_by_template(self, client: Courier) -> None:
         with client.automations.invoke.with_streaming_response.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -141,7 +141,7 @@ class TestInvoke:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `template_id` but received ''"):
             client.automations.invoke.with_raw_response.invoke_by_template(
                 template_id="",
-                recipient="recipient",
+                recipient="user_abc",
             )
 
 
@@ -221,7 +221,7 @@ class TestAsyncInvoke:
     async def test_method_invoke_by_template(self, async_client: AsyncCourier) -> None:
         invoke = await async_client.automations.invoke.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         )
         assert_matches_type(AutomationInvokeResponse, invoke, path=["response"])
 
@@ -230,10 +230,10 @@ class TestAsyncInvoke:
     async def test_method_invoke_by_template_with_all_params(self, async_client: AsyncCourier) -> None:
         invoke = await async_client.automations.invoke.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
             brand="brand",
-            data={"foo": "bar"},
-            profile={"foo": "bar"},
+            data={"orderId": "bar"},
+            profile={"email": "bar"},
             template="template",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
@@ -245,7 +245,7 @@ class TestAsyncInvoke:
     async def test_raw_response_invoke_by_template(self, async_client: AsyncCourier) -> None:
         response = await async_client.automations.invoke.with_raw_response.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         )
 
         assert response.is_closed is True
@@ -258,7 +258,7 @@ class TestAsyncInvoke:
     async def test_streaming_response_invoke_by_template(self, async_client: AsyncCourier) -> None:
         async with async_client.automations.invoke.with_streaming_response.invoke_by_template(
             template_id="templateId",
-            recipient="recipient",
+            recipient="user_abc",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -274,5 +274,5 @@ class TestAsyncInvoke:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `template_id` but received ''"):
             await async_client.automations.invoke.with_raw_response.invoke_by_template(
                 template_id="",
-                recipient="recipient",
+                recipient="user_abc",
             )

--- a/tests/api_resources/lists/test_subscriptions.py
+++ b/tests/api_resources/lists/test_subscriptions.py
@@ -75,7 +75,7 @@ class TestSubscriptions:
     def test_method_add(self, client: Courier) -> None:
         subscription = client.lists.subscriptions.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
         assert subscription is None
 
@@ -86,7 +86,7 @@ class TestSubscriptions:
             list_id="list_id",
             recipients=[
                 {
-                    "recipient_id": "recipientId",
+                    "recipient_id": "user_abc",
                     "preferences": {
                         "categories": {
                             "foo": {
@@ -113,7 +113,36 @@ class TestSubscriptions:
                             }
                         },
                     },
-                }
+                },
+                {
+                    "recipient_id": "user_def",
+                    "preferences": {
+                        "categories": {
+                            "foo": {
+                                "status": "OPTED_IN",
+                                "channel_preferences": [{"channel": "direct_message"}],
+                                "rules": [
+                                    {
+                                        "until": "until",
+                                        "start": "start",
+                                    }
+                                ],
+                            }
+                        },
+                        "notifications": {
+                            "foo": {
+                                "status": "OPTED_IN",
+                                "channel_preferences": [{"channel": "direct_message"}],
+                                "rules": [
+                                    {
+                                        "until": "until",
+                                        "start": "start",
+                                    }
+                                ],
+                            }
+                        },
+                    },
+                },
             ],
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
@@ -125,7 +154,7 @@ class TestSubscriptions:
     def test_raw_response_add(self, client: Courier) -> None:
         response = client.lists.subscriptions.with_raw_response.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
 
         assert response.is_closed is True
@@ -138,7 +167,7 @@ class TestSubscriptions:
     def test_streaming_response_add(self, client: Courier) -> None:
         with client.lists.subscriptions.with_streaming_response.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -154,7 +183,7 @@ class TestSubscriptions:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             client.lists.subscriptions.with_raw_response.add(
                 list_id="",
-                recipients=[{"recipient_id": "recipientId"}],
+                recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -162,7 +191,7 @@ class TestSubscriptions:
     def test_method_subscribe(self, client: Courier) -> None:
         subscription = client.lists.subscriptions.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
         assert subscription is None
 
@@ -171,7 +200,7 @@ class TestSubscriptions:
     def test_raw_response_subscribe(self, client: Courier) -> None:
         response = client.lists.subscriptions.with_raw_response.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
 
         assert response.is_closed is True
@@ -184,7 +213,7 @@ class TestSubscriptions:
     def test_streaming_response_subscribe(self, client: Courier) -> None:
         with client.lists.subscriptions.with_streaming_response.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -200,7 +229,7 @@ class TestSubscriptions:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             client.lists.subscriptions.with_raw_response.subscribe(
                 list_id="",
-                recipients=[{"recipient_id": "recipientId"}],
+                recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -232,7 +261,7 @@ class TestSubscriptions:
                     }
                 },
                 "notifications": {
-                    "foo": {
+                    "nt_01kx4h2jdafq8bk9aftxak4b40": {
                         "status": "OPTED_IN",
                         "channel_preferences": [{"channel": "direct_message"}],
                         "rules": [
@@ -404,7 +433,7 @@ class TestAsyncSubscriptions:
     async def test_method_add(self, async_client: AsyncCourier) -> None:
         subscription = await async_client.lists.subscriptions.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
         assert subscription is None
 
@@ -415,7 +444,7 @@ class TestAsyncSubscriptions:
             list_id="list_id",
             recipients=[
                 {
-                    "recipient_id": "recipientId",
+                    "recipient_id": "user_abc",
                     "preferences": {
                         "categories": {
                             "foo": {
@@ -442,7 +471,36 @@ class TestAsyncSubscriptions:
                             }
                         },
                     },
-                }
+                },
+                {
+                    "recipient_id": "user_def",
+                    "preferences": {
+                        "categories": {
+                            "foo": {
+                                "status": "OPTED_IN",
+                                "channel_preferences": [{"channel": "direct_message"}],
+                                "rules": [
+                                    {
+                                        "until": "until",
+                                        "start": "start",
+                                    }
+                                ],
+                            }
+                        },
+                        "notifications": {
+                            "foo": {
+                                "status": "OPTED_IN",
+                                "channel_preferences": [{"channel": "direct_message"}],
+                                "rules": [
+                                    {
+                                        "until": "until",
+                                        "start": "start",
+                                    }
+                                ],
+                            }
+                        },
+                    },
+                },
             ],
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
@@ -454,7 +512,7 @@ class TestAsyncSubscriptions:
     async def test_raw_response_add(self, async_client: AsyncCourier) -> None:
         response = await async_client.lists.subscriptions.with_raw_response.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
 
         assert response.is_closed is True
@@ -467,7 +525,7 @@ class TestAsyncSubscriptions:
     async def test_streaming_response_add(self, async_client: AsyncCourier) -> None:
         async with async_client.lists.subscriptions.with_streaming_response.add(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -483,7 +541,7 @@ class TestAsyncSubscriptions:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             await async_client.lists.subscriptions.with_raw_response.add(
                 list_id="",
-                recipients=[{"recipient_id": "recipientId"}],
+                recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -491,7 +549,7 @@ class TestAsyncSubscriptions:
     async def test_method_subscribe(self, async_client: AsyncCourier) -> None:
         subscription = await async_client.lists.subscriptions.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
         assert subscription is None
 
@@ -500,7 +558,7 @@ class TestAsyncSubscriptions:
     async def test_raw_response_subscribe(self, async_client: AsyncCourier) -> None:
         response = await async_client.lists.subscriptions.with_raw_response.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         )
 
         assert response.is_closed is True
@@ -513,7 +571,7 @@ class TestAsyncSubscriptions:
     async def test_streaming_response_subscribe(self, async_client: AsyncCourier) -> None:
         async with async_client.lists.subscriptions.with_streaming_response.subscribe(
             list_id="list_id",
-            recipients=[{"recipient_id": "recipientId"}],
+            recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -529,7 +587,7 @@ class TestAsyncSubscriptions:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             await async_client.lists.subscriptions.with_raw_response.subscribe(
                 list_id="",
-                recipients=[{"recipient_id": "recipientId"}],
+                recipients=[{"recipient_id": "user_abc"}, {"recipient_id": "user_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -561,7 +619,7 @@ class TestAsyncSubscriptions:
                     }
                 },
                 "notifications": {
-                    "foo": {
+                    "nt_01kx4h2jdafq8bk9aftxak4b40": {
                         "status": "OPTED_IN",
                         "channel_preferences": [{"channel": "direct_message"}],
                         "rules": [

--- a/tests/api_resources/notifications/test_checks.py
+++ b/tests/api_resources/notifications/test_checks.py
@@ -25,7 +25,7 @@ class TestChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -41,7 +41,7 @@ class TestChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -61,7 +61,7 @@ class TestChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -84,7 +84,7 @@ class TestChecks:
                 id="",
                 checks=[
                     {
-                        "id": "id",
+                        "id": "abc-123",
                         "status": "RESOLVED",
                         "type": "custom",
                     }
@@ -97,7 +97,7 @@ class TestChecks:
                 id="id",
                 checks=[
                     {
-                        "id": "id",
+                        "id": "abc-123",
                         "status": "RESOLVED",
                         "type": "custom",
                     }
@@ -222,7 +222,7 @@ class TestAsyncChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -238,7 +238,7 @@ class TestAsyncChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -258,7 +258,7 @@ class TestAsyncChecks:
             id="id",
             checks=[
                 {
-                    "id": "id",
+                    "id": "abc-123",
                     "status": "RESOLVED",
                     "type": "custom",
                 }
@@ -281,7 +281,7 @@ class TestAsyncChecks:
                 id="",
                 checks=[
                     {
-                        "id": "id",
+                        "id": "abc-123",
                         "status": "RESOLVED",
                         "type": "custom",
                     }
@@ -294,7 +294,7 @@ class TestAsyncChecks:
                 id="id",
                 checks=[
                     {
-                        "id": "id",
+                        "id": "abc-123",
                         "status": "RESOLVED",
                         "type": "custom",
                     }

--- a/tests/api_resources/profiles/test_lists.py
+++ b/tests/api_resources/profiles/test_lists.py
@@ -119,7 +119,7 @@ class TestLists:
     def test_method_subscribe(self, client: Courier) -> None:
         list_ = client.profiles.lists.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         )
         assert_matches_type(ListSubscribeResponse, list_, path=["response"])
 
@@ -130,7 +130,7 @@ class TestLists:
             user_id="user_id",
             lists=[
                 {
-                    "list_id": "listId",
+                    "list_id": "example.list.id",
                     "preferences": {
                         "categories": {
                             "foo": {
@@ -169,7 +169,7 @@ class TestLists:
     def test_raw_response_subscribe(self, client: Courier) -> None:
         response = client.profiles.lists.with_raw_response.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         )
 
         assert response.is_closed is True
@@ -182,7 +182,7 @@ class TestLists:
     def test_streaming_response_subscribe(self, client: Courier) -> None:
         with client.profiles.lists.with_streaming_response.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -198,7 +198,7 @@ class TestLists:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             client.profiles.lists.with_raw_response.subscribe(
                 user_id="",
-                lists=[{"list_id": "listId"}],
+                lists=[{"list_id": "example.list.id"}],
             )
 
 
@@ -305,7 +305,7 @@ class TestAsyncLists:
     async def test_method_subscribe(self, async_client: AsyncCourier) -> None:
         list_ = await async_client.profiles.lists.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         )
         assert_matches_type(ListSubscribeResponse, list_, path=["response"])
 
@@ -316,7 +316,7 @@ class TestAsyncLists:
             user_id="user_id",
             lists=[
                 {
-                    "list_id": "listId",
+                    "list_id": "example.list.id",
                     "preferences": {
                         "categories": {
                             "foo": {
@@ -355,7 +355,7 @@ class TestAsyncLists:
     async def test_raw_response_subscribe(self, async_client: AsyncCourier) -> None:
         response = await async_client.profiles.lists.with_raw_response.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         )
 
         assert response.is_closed is True
@@ -368,7 +368,7 @@ class TestAsyncLists:
     async def test_streaming_response_subscribe(self, async_client: AsyncCourier) -> None:
         async with async_client.profiles.lists.with_streaming_response.subscribe(
             user_id="user_id",
-            lists=[{"list_id": "listId"}],
+            lists=[{"list_id": "example.list.id"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -384,5 +384,5 @@ class TestAsyncLists:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             await async_client.profiles.lists.with_raw_response.subscribe(
                 user_id="",
-                lists=[{"list_id": "listId"}],
+                lists=[{"list_id": "example.list.id"}],
             )

--- a/tests/api_resources/tenants/test_templates.py
+++ b/tests/api_resources/tenants/test_templates.py
@@ -195,7 +195,7 @@ class TestTemplates:
         template = client.tenants.templates.publish(
             template_id="template_id",
             tenant_id="tenant_id",
-            version="version",
+            version="latest",
         )
         assert_matches_type(PostTenantTemplatePublishResponse, template, path=["response"])
 
@@ -251,7 +251,7 @@ class TestTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         )
@@ -274,7 +274,7 @@ class TestTemplates:
                             "type": "text",
                         }
                     ],
-                    "version": "version",
+                    "version": "2022-01-01",
                 },
                 "channels": {
                     "foo": {
@@ -315,8 +315,8 @@ class TestTemplates:
                     }
                 },
                 "routing": {
-                    "channels": ["string"],
-                    "method": "all",
+                    "channels": ["email"],
+                    "method": "single",
                 },
             },
             published=True,
@@ -332,7 +332,7 @@ class TestTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         )
@@ -351,7 +351,7 @@ class TestTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         ) as response:
@@ -373,7 +373,7 @@ class TestTemplates:
                 template={
                     "content": {
                         "elements": [{}],
-                        "version": "version",
+                        "version": "2022-01-01",
                     }
                 },
             )
@@ -385,7 +385,7 @@ class TestTemplates:
                 template={
                     "content": {
                         "elements": [{}],
-                        "version": "version",
+                        "version": "2022-01-01",
                     }
                 },
             )
@@ -567,7 +567,7 @@ class TestAsyncTemplates:
         template = await async_client.tenants.templates.publish(
             template_id="template_id",
             tenant_id="tenant_id",
-            version="version",
+            version="latest",
         )
         assert_matches_type(PostTenantTemplatePublishResponse, template, path=["response"])
 
@@ -623,7 +623,7 @@ class TestAsyncTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         )
@@ -646,7 +646,7 @@ class TestAsyncTemplates:
                             "type": "text",
                         }
                     ],
-                    "version": "version",
+                    "version": "2022-01-01",
                 },
                 "channels": {
                     "foo": {
@@ -687,8 +687,8 @@ class TestAsyncTemplates:
                     }
                 },
                 "routing": {
-                    "channels": ["string"],
-                    "method": "all",
+                    "channels": ["email"],
+                    "method": "single",
                 },
             },
             published=True,
@@ -704,7 +704,7 @@ class TestAsyncTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         )
@@ -723,7 +723,7 @@ class TestAsyncTemplates:
             template={
                 "content": {
                     "elements": [{}],
-                    "version": "version",
+                    "version": "2022-01-01",
                 }
             },
         ) as response:
@@ -745,7 +745,7 @@ class TestAsyncTemplates:
                 template={
                     "content": {
                         "elements": [{}],
-                        "version": "version",
+                        "version": "2022-01-01",
                     }
                 },
             )
@@ -757,7 +757,7 @@ class TestAsyncTemplates:
                 template={
                     "content": {
                         "elements": [{}],
-                        "version": "version",
+                        "version": "2022-01-01",
                     }
                 },
             )

--- a/tests/api_resources/test_audiences.py
+++ b/tests/api_resources/test_audiences.py
@@ -77,19 +77,19 @@ class TestAudiences:
     def test_method_update_with_all_params(self, client: Courier) -> None:
         audience = client.audiences.update(
             audience_id="audience_id",
-            description="description",
+            description="Users located in the US",
             filter={
                 "filters": [
                     {
-                        "operator": "operator",
+                        "operator": "EQ",
                         "filters": [],
-                        "path": "path",
-                        "value": "value",
+                        "path": "profile.location",
+                        "value": "US",
                     }
                 ],
                 "operator": "AND",
             },
-            name="name",
+            name="Engaged US Users",
             operator="AND",
         )
         assert_matches_type(AudienceUpdateResponse, audience, path=["response"])
@@ -318,19 +318,19 @@ class TestAsyncAudiences:
     async def test_method_update_with_all_params(self, async_client: AsyncCourier) -> None:
         audience = await async_client.audiences.update(
             audience_id="audience_id",
-            description="description",
+            description="Users located in the US",
             filter={
                 "filters": [
                     {
-                        "operator": "operator",
+                        "operator": "EQ",
                         "filters": [],
-                        "path": "path",
-                        "value": "value",
+                        "path": "profile.location",
+                        "value": "US",
                     }
                 ],
                 "operator": "AND",
             },
-            name="name",
+            name="Engaged US Users",
             operator="AND",
         )
         assert_matches_type(AudienceUpdateResponse, audience, path=["response"])

--- a/tests/api_resources/test_brands.py
+++ b/tests/api_resources/test_brands.py
@@ -185,7 +185,7 @@ class TestBrands:
     def test_method_update(self, client: Courier) -> None:
         brand = client.brands.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         )
         assert_matches_type(Brand, brand, path=["response"])
 
@@ -194,11 +194,11 @@ class TestBrands:
     def test_method_update_with_all_params(self, client: Courier) -> None:
         brand = client.brands.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
             settings={
                 "colors": {
-                    "primary": "primary",
-                    "secondary": "secondary",
+                    "primary": "#9D3789",
+                    "secondary": "#FFFFFF",
                 },
                 "email": {
                     "footer": {
@@ -273,7 +273,7 @@ class TestBrands:
     def test_raw_response_update(self, client: Courier) -> None:
         response = client.brands.with_raw_response.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         )
 
         assert response.is_closed is True
@@ -286,7 +286,7 @@ class TestBrands:
     def test_streaming_response_update(self, client: Courier) -> None:
         with client.brands.with_streaming_response.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -302,7 +302,7 @@ class TestBrands:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `brand_id` but received ''"):
             client.brands.with_raw_response.update(
                 brand_id="",
-                name="name",
+                name="My Brand",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -554,7 +554,7 @@ class TestAsyncBrands:
     async def test_method_update(self, async_client: AsyncCourier) -> None:
         brand = await async_client.brands.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         )
         assert_matches_type(Brand, brand, path=["response"])
 
@@ -563,11 +563,11 @@ class TestAsyncBrands:
     async def test_method_update_with_all_params(self, async_client: AsyncCourier) -> None:
         brand = await async_client.brands.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
             settings={
                 "colors": {
-                    "primary": "primary",
-                    "secondary": "secondary",
+                    "primary": "#9D3789",
+                    "secondary": "#FFFFFF",
                 },
                 "email": {
                     "footer": {
@@ -642,7 +642,7 @@ class TestAsyncBrands:
     async def test_raw_response_update(self, async_client: AsyncCourier) -> None:
         response = await async_client.brands.with_raw_response.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         )
 
         assert response.is_closed is True
@@ -655,7 +655,7 @@ class TestAsyncBrands:
     async def test_streaming_response_update(self, async_client: AsyncCourier) -> None:
         async with async_client.brands.with_streaming_response.update(
             brand_id="brand_id",
-            name="name",
+            name="My Brand",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -671,7 +671,7 @@ class TestAsyncBrands:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `brand_id` but received ''"):
             await async_client.brands.with_raw_response.update(
                 brand_id="",
-                name="name",
+                name="My Brand",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")

--- a/tests/api_resources/test_bulk.py
+++ b/tests/api_resources/test_bulk.py
@@ -71,7 +71,7 @@ class TestBulk:
     @parametrize
     def test_method_create_job(self, client: Courier) -> None:
         bulk = client.bulk.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         )
         assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
 
@@ -80,13 +80,13 @@ class TestBulk:
     def test_method_create_job_with_all_params(self, client: Courier) -> None:
         bulk = client.bulk.create_job(
             message={
-                "event": "event",
-                "brand": "brand",
+                "event": "welcome-series",
+                "brand": "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                 "content": {
                     "body": "body",
                     "title": "title",
                 },
-                "data": {"foo": "bar"},
+                "data": {"campaign": "bar"},
                 "locale": {"foo": {"foo": "bar"}},
                 "override": {"foo": "bar"},
                 "template": "template",
@@ -98,7 +98,7 @@ class TestBulk:
     @parametrize
     def test_raw_response_create_job(self, client: Courier) -> None:
         response = client.bulk.with_raw_response.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         )
 
         assert response.is_closed is True
@@ -110,7 +110,7 @@ class TestBulk:
     @parametrize
     def test_streaming_response_create_job(self, client: Courier) -> None:
         with client.bulk.with_streaming_response.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -311,7 +311,7 @@ class TestAsyncBulk:
     @parametrize
     async def test_method_create_job(self, async_client: AsyncCourier) -> None:
         bulk = await async_client.bulk.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         )
         assert_matches_type(BulkCreateJobResponse, bulk, path=["response"])
 
@@ -320,13 +320,13 @@ class TestAsyncBulk:
     async def test_method_create_job_with_all_params(self, async_client: AsyncCourier) -> None:
         bulk = await async_client.bulk.create_job(
             message={
-                "event": "event",
-                "brand": "brand",
+                "event": "welcome-series",
+                "brand": "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                 "content": {
                     "body": "body",
                     "title": "title",
                 },
-                "data": {"foo": "bar"},
+                "data": {"campaign": "bar"},
                 "locale": {"foo": {"foo": "bar"}},
                 "override": {"foo": "bar"},
                 "template": "template",
@@ -338,7 +338,7 @@ class TestAsyncBulk:
     @parametrize
     async def test_raw_response_create_job(self, async_client: AsyncCourier) -> None:
         response = await async_client.bulk.with_raw_response.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         )
 
         assert response.is_closed is True
@@ -350,7 +350,7 @@ class TestAsyncBulk:
     @parametrize
     async def test_streaming_response_create_job(self, async_client: AsyncCourier) -> None:
         async with async_client.bulk.with_streaming_response.create_job(
-            message={"event": "event"},
+            message={"event": "welcome-series"},
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"

--- a/tests/api_resources/test_lists.py
+++ b/tests/api_resources/test_lists.py
@@ -64,7 +64,7 @@ class TestLists:
     def test_method_update(self, client: Courier) -> None:
         list_ = client.lists.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         )
         assert list_ is None
 
@@ -73,7 +73,7 @@ class TestLists:
     def test_method_update_with_all_params(self, client: Courier) -> None:
         list_ = client.lists.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
             preferences={
                 "categories": {
                     "foo": {
@@ -108,7 +108,7 @@ class TestLists:
     def test_raw_response_update(self, client: Courier) -> None:
         response = client.lists.with_raw_response.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         )
 
         assert response.is_closed is True
@@ -121,7 +121,7 @@ class TestLists:
     def test_streaming_response_update(self, client: Courier) -> None:
         with client.lists.with_streaming_response.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -137,7 +137,7 @@ class TestLists:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             client.lists.with_raw_response.update(
                 list_id="",
-                name="name",
+                name="Product Updates",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -314,7 +314,7 @@ class TestAsyncLists:
     async def test_method_update(self, async_client: AsyncCourier) -> None:
         list_ = await async_client.lists.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         )
         assert list_ is None
 
@@ -323,7 +323,7 @@ class TestAsyncLists:
     async def test_method_update_with_all_params(self, async_client: AsyncCourier) -> None:
         list_ = await async_client.lists.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
             preferences={
                 "categories": {
                     "foo": {
@@ -358,7 +358,7 @@ class TestAsyncLists:
     async def test_raw_response_update(self, async_client: AsyncCourier) -> None:
         response = await async_client.lists.with_raw_response.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         )
 
         assert response.is_closed is True
@@ -371,7 +371,7 @@ class TestAsyncLists:
     async def test_streaming_response_update(self, async_client: AsyncCourier) -> None:
         async with async_client.lists.with_streaming_response.update(
             list_id="list_id",
-            name="name",
+            name="Product Updates",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -387,7 +387,7 @@ class TestAsyncLists:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `list_id` but received ''"):
             await async_client.lists.with_raw_response.update(
                 list_id="",
-                name="name",
+                name="Product Updates",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")

--- a/tests/api_resources/test_profiles.py
+++ b/tests/api_resources/test_profiles.py
@@ -26,7 +26,10 @@ class TestProfiles:
     def test_method_create(self, client: Courier) -> None:
         profile = client.profiles.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         )
         assert_matches_type(ProfileCreateResponse, profile, path=["response"])
 
@@ -35,7 +38,10 @@ class TestProfiles:
     def test_method_create_with_all_params(self, client: Courier) -> None:
         profile = client.profiles.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -46,7 +52,10 @@ class TestProfiles:
     def test_raw_response_create(self, client: Courier) -> None:
         response = client.profiles.with_raw_response.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         )
 
         assert response.is_closed is True
@@ -59,7 +68,10 @@ class TestProfiles:
     def test_streaming_response_create(self, client: Courier) -> None:
         with client.profiles.with_streaming_response.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -75,7 +87,10 @@ class TestProfiles:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             client.profiles.with_raw_response.create(
                 user_id="",
-                profile={"foo": "bar"},
+                profile={
+                    "email": "bar",
+                    "phone_number": "bar",
+                },
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -127,9 +142,9 @@ class TestProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         )
@@ -142,9 +157,9 @@ class TestProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         )
@@ -161,9 +176,9 @@ class TestProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         ) as response:
@@ -183,9 +198,9 @@ class TestProfiles:
                 user_id="",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
-                        "value": "value",
+                        "op": "replace",
+                        "path": "/email",
+                        "value": "jdoe@example.com",
                     }
                 ],
             )
@@ -237,7 +252,11 @@ class TestProfiles:
     def test_method_replace(self, client: Courier) -> None:
         profile = client.profiles.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         )
         assert_matches_type(ProfileReplaceResponse, profile, path=["response"])
 
@@ -246,7 +265,11 @@ class TestProfiles:
     def test_raw_response_replace(self, client: Courier) -> None:
         response = client.profiles.with_raw_response.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         )
 
         assert response.is_closed is True
@@ -259,7 +282,11 @@ class TestProfiles:
     def test_streaming_response_replace(self, client: Courier) -> None:
         with client.profiles.with_streaming_response.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -275,7 +302,11 @@ class TestProfiles:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             client.profiles.with_raw_response.replace(
                 user_id="",
-                profile={"foo": "bar"},
+                profile={
+                    "email": "bar",
+                    "phone_number": "bar",
+                    "locale": "bar",
+                },
             )
 
 
@@ -289,7 +320,10 @@ class TestAsyncProfiles:
     async def test_method_create(self, async_client: AsyncCourier) -> None:
         profile = await async_client.profiles.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         )
         assert_matches_type(ProfileCreateResponse, profile, path=["response"])
 
@@ -298,7 +332,10 @@ class TestAsyncProfiles:
     async def test_method_create_with_all_params(self, async_client: AsyncCourier) -> None:
         profile = await async_client.profiles.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -309,7 +346,10 @@ class TestAsyncProfiles:
     async def test_raw_response_create(self, async_client: AsyncCourier) -> None:
         response = await async_client.profiles.with_raw_response.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         )
 
         assert response.is_closed is True
@@ -322,7 +362,10 @@ class TestAsyncProfiles:
     async def test_streaming_response_create(self, async_client: AsyncCourier) -> None:
         async with async_client.profiles.with_streaming_response.create(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+            },
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -338,7 +381,10 @@ class TestAsyncProfiles:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             await async_client.profiles.with_raw_response.create(
                 user_id="",
-                profile={"foo": "bar"},
+                profile={
+                    "email": "bar",
+                    "phone_number": "bar",
+                },
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -390,9 +436,9 @@ class TestAsyncProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         )
@@ -405,9 +451,9 @@ class TestAsyncProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         )
@@ -424,9 +470,9 @@ class TestAsyncProfiles:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
-                    "value": "value",
+                    "op": "replace",
+                    "path": "/email",
+                    "value": "jdoe@example.com",
                 }
             ],
         ) as response:
@@ -446,9 +492,9 @@ class TestAsyncProfiles:
                 user_id="",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
-                        "value": "value",
+                        "op": "replace",
+                        "path": "/email",
+                        "value": "jdoe@example.com",
                     }
                 ],
             )
@@ -500,7 +546,11 @@ class TestAsyncProfiles:
     async def test_method_replace(self, async_client: AsyncCourier) -> None:
         profile = await async_client.profiles.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         )
         assert_matches_type(ProfileReplaceResponse, profile, path=["response"])
 
@@ -509,7 +559,11 @@ class TestAsyncProfiles:
     async def test_raw_response_replace(self, async_client: AsyncCourier) -> None:
         response = await async_client.profiles.with_raw_response.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         )
 
         assert response.is_closed is True
@@ -522,7 +576,11 @@ class TestAsyncProfiles:
     async def test_streaming_response_replace(self, async_client: AsyncCourier) -> None:
         async with async_client.profiles.with_streaming_response.replace(
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={
+                "email": "bar",
+                "phone_number": "bar",
+                "locale": "bar",
+            },
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -538,5 +596,9 @@ class TestAsyncProfiles:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             await async_client.profiles.with_raw_response.replace(
                 user_id="",
-                profile={"foo": "bar"},
+                profile={
+                    "email": "bar",
+                    "phone_number": "bar",
+                    "locale": "bar",
+                },
             )

--- a/tests/api_resources/test_providers.py
+++ b/tests/api_resources/test_providers.py
@@ -24,7 +24,7 @@ class TestProviders:
     @parametrize
     def test_method_create(self, client: Courier) -> None:
         provider = client.providers.create(
-            provider="provider",
+            provider="sendgrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -32,10 +32,10 @@ class TestProviders:
     @parametrize
     def test_method_create_with_all_params(self, client: Courier) -> None:
         provider = client.providers.create(
-            provider="provider",
+            provider="sendgrid",
             alias="alias",
-            settings={"foo": "bar"},
-            title="title",
+            settings={"api_key": "bar"},
+            title="Production SendGrid",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -45,7 +45,7 @@ class TestProviders:
     @parametrize
     def test_raw_response_create(self, client: Courier) -> None:
         response = client.providers.with_raw_response.create(
-            provider="provider",
+            provider="sendgrid",
         )
 
         assert response.is_closed is True
@@ -57,7 +57,7 @@ class TestProviders:
     @parametrize
     def test_streaming_response_create(self, client: Courier) -> None:
         with client.providers.with_streaming_response.create(
-            provider="provider",
+            provider="sendgrid",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -114,7 +114,7 @@ class TestProviders:
     def test_method_update(self, client: Courier) -> None:
         provider = client.providers.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -123,10 +123,10 @@ class TestProviders:
     def test_method_update_with_all_params(self, client: Courier) -> None:
         provider = client.providers.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
             alias="alias",
-            settings={"foo": "bar"},
-            title="title",
+            settings={"api_key": "bar"},
+            title="Production SendGrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -135,7 +135,7 @@ class TestProviders:
     def test_raw_response_update(self, client: Courier) -> None:
         response = client.providers.with_raw_response.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         )
 
         assert response.is_closed is True
@@ -148,7 +148,7 @@ class TestProviders:
     def test_streaming_response_update(self, client: Courier) -> None:
         with client.providers.with_streaming_response.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -164,7 +164,7 @@ class TestProviders:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `id` but received ''"):
             client.providers.with_raw_response.update(
                 id="",
-                provider="provider",
+                provider="sendgrid",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -255,7 +255,7 @@ class TestAsyncProviders:
     @parametrize
     async def test_method_create(self, async_client: AsyncCourier) -> None:
         provider = await async_client.providers.create(
-            provider="provider",
+            provider="sendgrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -263,10 +263,10 @@ class TestAsyncProviders:
     @parametrize
     async def test_method_create_with_all_params(self, async_client: AsyncCourier) -> None:
         provider = await async_client.providers.create(
-            provider="provider",
+            provider="sendgrid",
             alias="alias",
-            settings={"foo": "bar"},
-            title="title",
+            settings={"api_key": "bar"},
+            title="Production SendGrid",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -276,7 +276,7 @@ class TestAsyncProviders:
     @parametrize
     async def test_raw_response_create(self, async_client: AsyncCourier) -> None:
         response = await async_client.providers.with_raw_response.create(
-            provider="provider",
+            provider="sendgrid",
         )
 
         assert response.is_closed is True
@@ -288,7 +288,7 @@ class TestAsyncProviders:
     @parametrize
     async def test_streaming_response_create(self, async_client: AsyncCourier) -> None:
         async with async_client.providers.with_streaming_response.create(
-            provider="provider",
+            provider="sendgrid",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -345,7 +345,7 @@ class TestAsyncProviders:
     async def test_method_update(self, async_client: AsyncCourier) -> None:
         provider = await async_client.providers.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -354,10 +354,10 @@ class TestAsyncProviders:
     async def test_method_update_with_all_params(self, async_client: AsyncCourier) -> None:
         provider = await async_client.providers.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
             alias="alias",
-            settings={"foo": "bar"},
-            title="title",
+            settings={"api_key": "bar"},
+            title="Production SendGrid",
         )
         assert_matches_type(Provider, provider, path=["response"])
 
@@ -366,7 +366,7 @@ class TestAsyncProviders:
     async def test_raw_response_update(self, async_client: AsyncCourier) -> None:
         response = await async_client.providers.with_raw_response.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         )
 
         assert response.is_closed is True
@@ -379,7 +379,7 @@ class TestAsyncProviders:
     async def test_streaming_response_update(self, async_client: AsyncCourier) -> None:
         async with async_client.providers.with_streaming_response.update(
             id="id",
-            provider="provider",
+            provider="sendgrid",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -395,7 +395,7 @@ class TestAsyncProviders:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `id` but received ''"):
             await async_client.providers.with_raw_response.update(
                 id="",
-                provider="provider",
+                provider="sendgrid",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")

--- a/tests/api_resources/test_tenants.py
+++ b/tests/api_resources/test_tenants.py
@@ -68,7 +68,7 @@ class TestTenants:
     def test_method_update(self, client: Courier) -> None:
         tenant = client.tenants.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         )
         assert_matches_type(Tenant, tenant, path=["response"])
 
@@ -77,8 +77,8 @@ class TestTenants:
     def test_method_update_with_all_params(self, client: Courier) -> None:
         tenant = client.tenants.update(
             tenant_id="tenant_id",
-            name="name",
-            brand_id="brand_id",
+            name="Acme Corp",
+            brand_id="bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
             default_preferences={
                 "items": [
                     {
@@ -90,7 +90,7 @@ class TestTenants:
                 ]
             },
             parent_tenant_id="parent_tenant_id",
-            properties={"foo": "bar"},
+            properties={"plan": "bar"},
             user_profile={"foo": "bar"},
         )
         assert_matches_type(Tenant, tenant, path=["response"])
@@ -100,7 +100,7 @@ class TestTenants:
     def test_raw_response_update(self, client: Courier) -> None:
         response = client.tenants.with_raw_response.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         )
 
         assert response.is_closed is True
@@ -113,7 +113,7 @@ class TestTenants:
     def test_streaming_response_update(self, client: Courier) -> None:
         with client.tenants.with_streaming_response.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -129,7 +129,7 @@ class TestTenants:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `tenant_id` but received ''"):
             client.tenants.with_raw_response.update(
                 tenant_id="",
-                name="name",
+                name="Acme Corp",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -317,7 +317,7 @@ class TestAsyncTenants:
     async def test_method_update(self, async_client: AsyncCourier) -> None:
         tenant = await async_client.tenants.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         )
         assert_matches_type(Tenant, tenant, path=["response"])
 
@@ -326,8 +326,8 @@ class TestAsyncTenants:
     async def test_method_update_with_all_params(self, async_client: AsyncCourier) -> None:
         tenant = await async_client.tenants.update(
             tenant_id="tenant_id",
-            name="name",
-            brand_id="brand_id",
+            name="Acme Corp",
+            brand_id="bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
             default_preferences={
                 "items": [
                     {
@@ -339,7 +339,7 @@ class TestAsyncTenants:
                 ]
             },
             parent_tenant_id="parent_tenant_id",
-            properties={"foo": "bar"},
+            properties={"plan": "bar"},
             user_profile={"foo": "bar"},
         )
         assert_matches_type(Tenant, tenant, path=["response"])
@@ -349,7 +349,7 @@ class TestAsyncTenants:
     async def test_raw_response_update(self, async_client: AsyncCourier) -> None:
         response = await async_client.tenants.with_raw_response.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         )
 
         assert response.is_closed is True
@@ -362,7 +362,7 @@ class TestAsyncTenants:
     async def test_streaming_response_update(self, async_client: AsyncCourier) -> None:
         async with async_client.tenants.with_streaming_response.update(
             tenant_id="tenant_id",
-            name="name",
+            name="Acme Corp",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -378,7 +378,7 @@ class TestAsyncTenants:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `tenant_id` but received ''"):
             await async_client.tenants.with_raw_response.update(
                 tenant_id="",
-                name="name",
+                name="Acme Corp",
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")

--- a/tests/api_resources/test_translations.py
+++ b/tests/api_resources/test_translations.py
@@ -74,7 +74,7 @@ class TestTranslations:
         translation = client.translations.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         )
         assert translation is None
 
@@ -84,7 +84,7 @@ class TestTranslations:
         response = client.translations.with_raw_response.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         )
 
         assert response.is_closed is True
@@ -98,7 +98,7 @@ class TestTranslations:
         with client.translations.with_streaming_response.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -115,14 +115,14 @@ class TestTranslations:
             client.translations.with_raw_response.update(
                 locale="locale",
                 domain="",
-                body="body",
+                body='msgid "Hello"\nmsgstr "Hola"',
             )
 
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `locale` but received ''"):
             client.translations.with_raw_response.update(
                 locale="",
                 domain="domain",
-                body="body",
+                body='msgid "Hello"\nmsgstr "Hola"',
             )
 
 
@@ -189,7 +189,7 @@ class TestAsyncTranslations:
         translation = await async_client.translations.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         )
         assert translation is None
 
@@ -199,7 +199,7 @@ class TestAsyncTranslations:
         response = await async_client.translations.with_raw_response.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         )
 
         assert response.is_closed is True
@@ -213,7 +213,7 @@ class TestAsyncTranslations:
         async with async_client.translations.with_streaming_response.update(
             locale="locale",
             domain="domain",
-            body="body",
+            body='msgid "Hello"\nmsgstr "Hola"',
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -230,12 +230,12 @@ class TestAsyncTranslations:
             await async_client.translations.with_raw_response.update(
                 locale="locale",
                 domain="",
-                body="body",
+                body='msgid "Hello"\nmsgstr "Hola"',
             )
 
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `locale` but received ''"):
             await async_client.translations.with_raw_response.update(
                 locale="",
                 domain="domain",
-                body="body",
+                body='msgid "Hello"\nmsgstr "Hola"',
             )

--- a/tests/api_resources/test_workspace_preferences.py
+++ b/tests/api_resources/test_workspace_preferences.py
@@ -190,9 +190,9 @@ class TestWorkspacePreferences:
     @parametrize
     def test_method_publish_with_all_params(self, client: Courier) -> None:
         workspace_preference = client.workspace_preferences.publish(
-            brand_id="brand_id",
-            description="description",
-            heading="heading",
+            brand_id="bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            description="Choose what you hear from us about.",
+            heading="Notification Preferences",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -225,7 +225,7 @@ class TestWorkspacePreferences:
     def test_method_replace(self, client: Courier) -> None:
         workspace_preference = client.workspace_preferences.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         )
         assert_matches_type(WorkspacePreferenceGetResponse, workspace_preference, path=["response"])
 
@@ -234,10 +234,10 @@ class TestWorkspacePreferences:
     def test_method_replace_with_all_params(self, client: Courier) -> None:
         workspace_preference = client.workspace_preferences.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
             description="description",
             has_custom_routing=True,
-            routing_options=["direct_message"],
+            routing_options=["email", "push"],
         )
         assert_matches_type(WorkspacePreferenceGetResponse, workspace_preference, path=["response"])
 
@@ -246,7 +246,7 @@ class TestWorkspacePreferences:
     def test_raw_response_replace(self, client: Courier) -> None:
         response = client.workspace_preferences.with_raw_response.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         )
 
         assert response.is_closed is True
@@ -259,7 +259,7 @@ class TestWorkspacePreferences:
     def test_streaming_response_replace(self, client: Courier) -> None:
         with client.workspace_preferences.with_streaming_response.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -275,7 +275,7 @@ class TestWorkspacePreferences:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `section_id` but received ''"):
             client.workspace_preferences.with_raw_response.replace(
                 section_id="",
-                name="name",
+                name="Account Notifications",
             )
 
 
@@ -453,9 +453,9 @@ class TestAsyncWorkspacePreferences:
     @parametrize
     async def test_method_publish_with_all_params(self, async_client: AsyncCourier) -> None:
         workspace_preference = await async_client.workspace_preferences.publish(
-            brand_id="brand_id",
-            description="description",
-            heading="heading",
+            brand_id="bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            description="Choose what you hear from us about.",
+            heading="Notification Preferences",
             idempotency_key="order-ORD-456-user-123",
             x_idempotency_expiration="1785312000",
         )
@@ -488,7 +488,7 @@ class TestAsyncWorkspacePreferences:
     async def test_method_replace(self, async_client: AsyncCourier) -> None:
         workspace_preference = await async_client.workspace_preferences.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         )
         assert_matches_type(WorkspacePreferenceGetResponse, workspace_preference, path=["response"])
 
@@ -497,10 +497,10 @@ class TestAsyncWorkspacePreferences:
     async def test_method_replace_with_all_params(self, async_client: AsyncCourier) -> None:
         workspace_preference = await async_client.workspace_preferences.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
             description="description",
             has_custom_routing=True,
-            routing_options=["direct_message"],
+            routing_options=["email", "push"],
         )
         assert_matches_type(WorkspacePreferenceGetResponse, workspace_preference, path=["response"])
 
@@ -509,7 +509,7 @@ class TestAsyncWorkspacePreferences:
     async def test_raw_response_replace(self, async_client: AsyncCourier) -> None:
         response = await async_client.workspace_preferences.with_raw_response.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         )
 
         assert response.is_closed is True
@@ -522,7 +522,7 @@ class TestAsyncWorkspacePreferences:
     async def test_streaming_response_replace(self, async_client: AsyncCourier) -> None:
         async with async_client.workspace_preferences.with_streaming_response.replace(
             section_id="section_id",
-            name="name",
+            name="Account Notifications",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -538,5 +538,5 @@ class TestAsyncWorkspacePreferences:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `section_id` but received ''"):
             await async_client.workspace_preferences.with_raw_response.replace(
                 section_id="",
-                name="name",
+                name="Account Notifications",
             )

--- a/tests/api_resources/users/test_tenants.py
+++ b/tests/api_resources/users/test_tenants.py
@@ -76,7 +76,7 @@ class TestTenants:
     def test_method_add_multiple(self, client: Courier) -> None:
         tenant = client.users.tenants.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         )
         assert tenant is None
 
@@ -85,7 +85,7 @@ class TestTenants:
     def test_raw_response_add_multiple(self, client: Courier) -> None:
         response = client.users.tenants.with_raw_response.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         )
 
         assert response.is_closed is True
@@ -98,7 +98,7 @@ class TestTenants:
     def test_streaming_response_add_multiple(self, client: Courier) -> None:
         with client.users.tenants.with_streaming_response.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -114,7 +114,7 @@ class TestTenants:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             client.users.tenants.with_raw_response.add_multiple(
                 user_id="",
-                tenants=[{"tenant_id": "tenant_id"}],
+                tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -132,7 +132,7 @@ class TestTenants:
         tenant = client.users.tenants.add_single(
             tenant_id="tenant_id",
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={"role": "bar"},
         )
         assert tenant is None
 
@@ -336,7 +336,7 @@ class TestAsyncTenants:
     async def test_method_add_multiple(self, async_client: AsyncCourier) -> None:
         tenant = await async_client.users.tenants.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         )
         assert tenant is None
 
@@ -345,7 +345,7 @@ class TestAsyncTenants:
     async def test_raw_response_add_multiple(self, async_client: AsyncCourier) -> None:
         response = await async_client.users.tenants.with_raw_response.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         )
 
         assert response.is_closed is True
@@ -358,7 +358,7 @@ class TestAsyncTenants:
     async def test_streaming_response_add_multiple(self, async_client: AsyncCourier) -> None:
         async with async_client.users.tenants.with_streaming_response.add_multiple(
             user_id="user_id",
-            tenants=[{"tenant_id": "tenant_id"}],
+            tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -374,7 +374,7 @@ class TestAsyncTenants:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `user_id` but received ''"):
             await async_client.users.tenants.with_raw_response.add_multiple(
                 user_id="",
-                tenants=[{"tenant_id": "tenant_id"}],
+                tenants=[{"tenant_id": "tenant_abc"}, {"tenant_id": "tenant_def"}],
             )
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -392,7 +392,7 @@ class TestAsyncTenants:
         tenant = await async_client.users.tenants.add_single(
             tenant_id="tenant_id",
             user_id="user_id",
-            profile={"foo": "bar"},
+            profile={"role": "bar"},
         )
         assert tenant is None
 

--- a/tests/api_resources/users/test_tokens.py
+++ b/tests/api_resources/users/test_tokens.py
@@ -77,8 +77,8 @@ class TestTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         )
@@ -92,8 +92,8 @@ class TestTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         )
@@ -111,8 +111,8 @@ class TestTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         ) as response:
@@ -133,8 +133,8 @@ class TestTokens:
                 user_id="",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
+                        "op": "replace",
+                        "path": "/expiry_date",
                     }
                 ],
             )
@@ -145,8 +145,8 @@ class TestTokens:
                 user_id="user_id",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
+                        "op": "replace",
+                        "path": "/expiry_date",
                     }
                 ],
             )
@@ -306,7 +306,7 @@ class TestTokens:
             provider_key="firebase-fcm",
             device={
                 "ad_id": "ad_id",
-                "app_id": "app_id",
+                "app_id": "com.example.app",
                 "device_id": "device_id",
                 "manufacturer": "manufacturer",
                 "model": "model",
@@ -436,8 +436,8 @@ class TestAsyncTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         )
@@ -451,8 +451,8 @@ class TestAsyncTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         )
@@ -470,8 +470,8 @@ class TestAsyncTokens:
             user_id="user_id",
             patch=[
                 {
-                    "op": "op",
-                    "path": "path",
+                    "op": "replace",
+                    "path": "/expiry_date",
                 }
             ],
         ) as response:
@@ -492,8 +492,8 @@ class TestAsyncTokens:
                 user_id="",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
+                        "op": "replace",
+                        "path": "/expiry_date",
                     }
                 ],
             )
@@ -504,8 +504,8 @@ class TestAsyncTokens:
                 user_id="user_id",
                 patch=[
                     {
-                        "op": "op",
-                        "path": "path",
+                        "op": "replace",
+                        "path": "/expiry_date",
                     }
                 ],
             )
@@ -665,7 +665,7 @@ class TestAsyncTokens:
             provider_key="firebase-fcm",
             device={
                 "ad_id": "ad_id",
-                "app_id": "app_id",
+                "app_id": "com.example.app",
                 "device_id": "device_id",
                 "manufacturer": "manufacturer",
                 "model": "model",

--- a/tests/api_resources/workspace_preferences/test_topics.py
+++ b/tests/api_resources/workspace_preferences/test_topics.py
@@ -236,8 +236,8 @@ class TestTopics:
         topic = client.workspace_preferences.topics.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         )
         assert_matches_type(WorkspacePreferenceTopicGetResponse, topic, path=["response"])
 
@@ -247,12 +247,12 @@ class TestTopics:
         topic = client.workspace_preferences.topics.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
-            allowed_preferences=["snooze"],
+            default_status="OPTED_IN",
+            name="Product Updates",
+            allowed_preferences=["channel_preferences"],
             description="description",
             include_unsubscribe_header=True,
-            routing_options=["direct_message"],
+            routing_options=["email", "inbox"],
             topic_data={"foo": "bar"},
         )
         assert_matches_type(WorkspacePreferenceTopicGetResponse, topic, path=["response"])
@@ -263,8 +263,8 @@ class TestTopics:
         response = client.workspace_preferences.topics.with_raw_response.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         )
 
         assert response.is_closed is True
@@ -278,8 +278,8 @@ class TestTopics:
         with client.workspace_preferences.topics.with_streaming_response.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -296,16 +296,16 @@ class TestTopics:
             client.workspace_preferences.topics.with_raw_response.replace(
                 topic_id="topic_id",
                 section_id="",
-                default_status="OPTED_OUT",
-                name="name",
+                default_status="OPTED_IN",
+                name="Product Updates",
             )
 
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `topic_id` but received ''"):
             client.workspace_preferences.topics.with_raw_response.replace(
                 topic_id="",
                 section_id="section_id",
-                default_status="OPTED_OUT",
-                name="name",
+                default_status="OPTED_IN",
+                name="Product Updates",
             )
 
 
@@ -533,8 +533,8 @@ class TestAsyncTopics:
         topic = await async_client.workspace_preferences.topics.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         )
         assert_matches_type(WorkspacePreferenceTopicGetResponse, topic, path=["response"])
 
@@ -544,12 +544,12 @@ class TestAsyncTopics:
         topic = await async_client.workspace_preferences.topics.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
-            allowed_preferences=["snooze"],
+            default_status="OPTED_IN",
+            name="Product Updates",
+            allowed_preferences=["channel_preferences"],
             description="description",
             include_unsubscribe_header=True,
-            routing_options=["direct_message"],
+            routing_options=["email", "inbox"],
             topic_data={"foo": "bar"},
         )
         assert_matches_type(WorkspacePreferenceTopicGetResponse, topic, path=["response"])
@@ -560,8 +560,8 @@ class TestAsyncTopics:
         response = await async_client.workspace_preferences.topics.with_raw_response.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         )
 
         assert response.is_closed is True
@@ -575,8 +575,8 @@ class TestAsyncTopics:
         async with async_client.workspace_preferences.topics.with_streaming_response.replace(
             topic_id="topic_id",
             section_id="section_id",
-            default_status="OPTED_OUT",
-            name="name",
+            default_status="OPTED_IN",
+            name="Product Updates",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -593,14 +593,14 @@ class TestAsyncTopics:
             await async_client.workspace_preferences.topics.with_raw_response.replace(
                 topic_id="topic_id",
                 section_id="",
-                default_status="OPTED_OUT",
-                name="name",
+                default_status="OPTED_IN",
+                name="Product Updates",
             )
 
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `topic_id` but received ''"):
             await async_client.workspace_preferences.topics.with_raw_response.replace(
                 topic_id="",
                 section_id="section_id",
-                default_status="OPTED_OUT",
-                name="name",
+                default_status="OPTED_IN",
+                name="Product Updates",
             )


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

17 files changed, 410 insertions(+), 290 deletions(-)

<details><summary>Files</summary>

```
 tests/api_resources/automations/test_invoke.py           |  28 +++----
 tests/api_resources/lists/test_subscriptions.py          | 102 ++++++++++++++++++------
 tests/api_resources/notifications/test_checks.py         |  20 ++---
 tests/api_resources/profiles/test_lists.py               |  20 ++---
 tests/api_resources/tenants/test_templates.py            |  36 ++++-----
 tests/api_resources/test_audiences.py                    |  20 ++---
 tests/api_resources/test_brands.py                       |  28 +++----
 tests/api_resources/test_bulk.py                         |  24 +++---
 tests/api_resources/test_lists.py                        |  20 ++---
 tests/api_resources/test_profiles.py                     | 146 +++++++++++++++++++++++++----------
 tests/api_resources/test_providers.py                    |  52 ++++++-------
 tests/api_resources/test_tenants.py                      |  28 +++----
 tests/api_resources/test_translations.py                 |  20 ++---
 tests/api_resources/test_workspace_preferences.py        |  36 ++++-----
 tests/api_resources/users/test_tenants.py                |  20 ++---
 tests/api_resources/users/test_tokens.py                 |  44 +++++------
 tests/api_resources/workspace_preferences/test_topics.py |  56 +++++++-------
 17 files changed, 410 insertions(+), 290 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
