### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/src/courier/resources/bulk.py
+++ b/src/courier/resources/bulk.py
@@ -145,7 +145,8 @@ class BulkResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> BulkListUsersResponse:
         """
-        Get Bulk Job Users
+        Returns the users ingested into a bulk job with paging, each carrying the status
+        Courier recorded for it and the id of the message it produced.
 
         Args:
           cursor: A unique identifier that allows for fetching the next set of users added to the
@@ -185,7 +186,9 @@ class BulkResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> BulkRetrieveJobResponse:
         """
-        Get a bulk job
+        Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+        COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+        and failures. Poll it to follow a job through to completion.
 
         Args:
           extra_headers: Send extra headers
@@ -217,8 +220,11 @@ class BulkResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> None:
-        """
-        Run a bulk job
+        """Starts processing a bulk job, sending to every user ingested into it.
+
+        Returns
+        204 immediately; the job runs asynchronously, so poll the job to watch its
+        status and counts.
 
         Args:
           extra_headers: Send extra headers
@@ -359,7 +365,8 @@ class AsyncBulkResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> BulkListUsersResponse:
         """
-        Get Bulk Job Users
+        Returns the users ingested into a bulk job with paging, each carrying the status
+        Courier recorded for it and the id of the message it produced.
 
         Args:
           cursor: A unique identifier that allows for fetching the next set of users added to the
@@ -399,7 +406,9 @@ class AsyncBulkResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> BulkRetrieveJobResponse:
         """
-        Get a bulk job
+        Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+        COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+        and failures. Poll it to follow a job through to completion.
 
         Args:
           extra_headers: Send extra headers
@@ -431,8 +440,11 @@ class AsyncBulkResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> None:
-        """
-        Run a bulk job
+        """Starts processing a bulk job, sending to every user ingested into it.
+
+        Returns
+        204 immediately; the job runs asynchronously, so poll the job to watch its
+        status and counts.
 
         Args:
           extra_headers: Send extra headers


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 20 insertions(+), 8 deletions(-)

<details><summary>Files</summary>

```
 src/courier/resources/bulk.py | 28 ++++++++++++++++++++--------
 1 file changed, 20 insertions(+), 8 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
