### PR TITLE
feat(api)!: nest the AWS SNS target_arn under aws_sns on the user profile

### DIFF
--- a/api.md
+++ b/api.md
@@ -8,6 +8,7 @@ from courier.types import (
     AudienceFilter,
     AudienceFilterConfig,
     AudienceRecipient,
+    AwsSns,
     Channel,
     ChannelClassification,
     ChannelMetadata,

--- a/src/courier/types/__init__.py
+++ b/src/courier/types/__init__.py
@@ -25,6 +25,7 @@ from .shared import (
     Rule as Rule,
     Slack as Slack,
     Token as Token,
+    AwsSns as AwsSns,
     Paging as Paging,
     Channel as Channel,
     Discord as Discord,

--- a/src/courier/types/shared/__init__.py
+++ b/src/courier/types/shared/__init__.py
@@ -6,6 +6,7 @@ from .rule import Rule as Rule
 from .slack import Slack as Slack
 from .token import Token as Token
 from .paging import Paging as Paging
+from .aws_sns import AwsSns as AwsSns
 from .channel import Channel as Channel
 from .discord import Discord as Discord
 from .intercom import Intercom as Intercom

--- a/src/courier/types/shared/aws_sns.py
+++ b/src/courier/types/shared/aws_sns.py
@@ -1,0 +1,15 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from ..._models import BaseModel
+
+__all__ = ["AwsSns"]
+
+
+class AwsSns(BaseModel):
+    """Routes a push notification through the AWS SNS provider.
+
+    The target ARN must be nested under `aws_sns` — a top-level `target_arn` on the profile is ignored by the provider.
+    """
+
+    target_arn: str
+    """The ARN of the SNS platform endpoint, topic, or application to publish to."""

--- a/src/courier/types/shared/user_profile.py
+++ b/src/courier/types/shared/user_profile.py
@@ -6,6 +6,7 @@ from pydantic import Field as FieldInfo
 
 from .expo import Expo
 from .slack import Slack
+from .aws_sns import AwsSns
 from .discord import Discord
 from .intercom import Intercom
 from .ms_teams import MsTeams
@@ -36,6 +37,13 @@ class UserProfile(BaseModel):
     airship: Optional[AirshipProfile] = None
 
     apn: Optional[str] = None
+
+    aws_sns: Optional[AwsSns] = None
+    """Routes a push notification through the AWS SNS provider.
+
+    The target ARN must be nested under `aws_sns` — a top-level `target_arn` on the
+    profile is ignored by the provider.
+    """
 
     birthdate: Optional[str] = None
 
@@ -89,8 +97,6 @@ class UserProfile(BaseModel):
     slack: Optional[Slack] = None
 
     sub: Optional[str] = None
-
-    target_arn: Optional[str] = None
 
     updated_at: Optional[str] = None
 


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

5 files changed, 26 insertions(+), 2 deletions(-)

<details><summary>Files</summary>

```
 api.md                                   |  1 +
 src/courier/types/__init__.py            |  1 +
 src/courier/types/shared/__init__.py     |  1 +
 src/courier/types/shared/aws_sns.py      | 15 +++++++++++++++
 src/courier/types/shared/user_profile.py | 10 ++++++++--
 5 files changed, 26 insertions(+), 2 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
