### PR TITLE
feat(api)!: match the spec to the backend — apn/expo token types and the phantom notifications.duplicate

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 150
+configured_endpoints: 149

--- a/api.md
+++ b/api.md
@@ -5,6 +5,7 @@ from courier.types import (
     AirshipProfile,
     AirshipProfileAudience,
     Alignment,
+    Apn,
     AudienceFilter,
     AudienceFilterConfig,
     AudienceRecipient,
@@ -475,7 +476,6 @@ Methods:
 - <code title="get /notifications/{id}">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">retrieve</a>(id, \*\*<a href="src/courier/types/notification_retrieve_params.py">params</a>) -> <a href="./src/courier/types/notification_template_response.py">NotificationTemplateResponse</a></code>
 - <code title="get /notifications">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">list</a>(\*\*<a href="src/courier/types/notification_list_params.py">params</a>) -> <a href="./src/courier/types/notification_list_response.py">NotificationListResponse</a></code>
 - <code title="delete /notifications/{id}">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">archive</a>(id) -> None</code>
-- <code title="post /notifications/{id}/duplicate">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">duplicate</a>(id) -> <a href="./src/courier/types/notification_template_response.py">NotificationTemplateResponse</a></code>
 - <code title="get /notifications/{id}/versions">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">list_versions</a>(id, \*\*<a href="src/courier/types/notification_list_versions_params.py">params</a>) -> <a href="./src/courier/types/notification_template_version_list_response.py">NotificationTemplateVersionListResponse</a></code>
 - <code title="post /notifications/{id}/publish">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">publish</a>(id, \*\*<a href="src/courier/types/notification_publish_params.py">params</a>) -> None</code>
 - <code title="put /notifications/{id}/content">client.notifications.<a href="./src/courier/resources/notifications/notifications.py">put_content</a>(id, \*\*<a href="src/courier/types/notification_put_content_params.py">params</a>) -> <a href="./src/courier/types/notification_content_mutation_response.py">NotificationContentMutationResponse</a></code>

--- a/src/courier/resources/notifications/notifications.py
+++ b/src/courier/resources/notifications/notifications.py
@@ -270,41 +270,6 @@ class NotificationsResource(SyncAPIResource):
             cast_to=NoneType,
         )
 
-    def duplicate(
-        self,
-        id: str,
-        *,
-        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
-        # The extra values given here take precedence over values defined on the client or passed to this method.
-        extra_headers: Headers | None = None,
-        extra_query: Query | None = None,
-        extra_body: Body | None = None,
-        timeout: float | httpx.Timeout | None | NotGiven = not_given,
-    ) -> NotificationTemplateResponse:
-        """
-        Copies a notification template within the same workspace and environment,
-        appending " COPY" to the title. The copy is standalone and independently
-        editable.
-
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        if not id:
-            raise ValueError(f"Expected a non-empty value for `id` but received {id!r}")
-        return self._post(
-            path_template("/notifications/{id}/duplicate", id=id),
-            options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
-            ),
-            cast_to=NotificationTemplateResponse,
-        )
-
     def list_versions(
         self,
         id: str,
@@ -887,41 +852,6 @@ class AsyncNotificationsResource(AsyncAPIResource):
             cast_to=NoneType,
         )
 
-    async def duplicate(
-        self,
-        id: str,
-        *,
-        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
-        # The extra values given here take precedence over values defined on the client or passed to this method.
-        extra_headers: Headers | None = None,
-        extra_query: Query | None = None,
-        extra_body: Body | None = None,
-        timeout: float | httpx.Timeout | None | NotGiven = not_given,
-    ) -> NotificationTemplateResponse:
-        """
-        Copies a notification template within the same workspace and environment,
-        appending " COPY" to the title. The copy is standalone and independently
-        editable.
-
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        if not id:
-            raise ValueError(f"Expected a non-empty value for `id` but received {id!r}")
-        return await self._post(
-            path_template("/notifications/{id}/duplicate", id=id),
-            options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
-            ),
-            cast_to=NotificationTemplateResponse,
-        )
-
     async def list_versions(
         self,
         id: str,
@@ -1300,9 +1230,6 @@ class NotificationsResourceWithRawResponse:
         self.archive = to_raw_response_wrapper(
             notifications.archive,
         )
-        self.duplicate = to_raw_response_wrapper(
-            notifications.duplicate,
-        )
         self.list_versions = to_raw_response_wrapper(
             notifications.list_versions,
         )
@@ -1348,9 +1275,6 @@ class AsyncNotificationsResourceWithRawResponse:
         )
         self.archive = async_to_raw_response_wrapper(
             notifications.archive,
-        )
-        self.duplicate = async_to_raw_response_wrapper(
-            notifications.duplicate,
         )
         self.list_versions = async_to_raw_response_wrapper(
             notifications.list_versions,
@@ -1398,9 +1322,6 @@ class NotificationsResourceWithStreamingResponse:
         self.archive = to_streamed_response_wrapper(
             notifications.archive,
         )
-        self.duplicate = to_streamed_response_wrapper(
-            notifications.duplicate,
-        )
         self.list_versions = to_streamed_response_wrapper(
             notifications.list_versions,
         )
@@ -1446,9 +1367,6 @@ class AsyncNotificationsResourceWithStreamingResponse:
         )
         self.archive = async_to_streamed_response_wrapper(
             notifications.archive,
-        )
-        self.duplicate = async_to_streamed_response_wrapper(
-            notifications.duplicate,
         )
         self.list_versions = async_to_streamed_response_wrapper(
             notifications.list_versions,

--- a/src/courier/types/__init__.py
+++ b/src/courier/types/__init__.py
@@ -20,6 +20,7 @@ from .brand import Brand as Brand
 from .check import Check as Check
 from .icons import Icons as Icons
 from .shared import (
+    Apn as Apn,
     Utm as Utm,
     Expo as Expo,
     Rule as Rule,

--- a/src/courier/types/shared/__init__.py
+++ b/src/courier/types/shared/__init__.py
@@ -1,5 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
+from .apn import Apn as Apn
 from .utm import Utm as Utm
 from .expo import Expo as Expo
 from .rule import Rule as Rule

--- a/src/courier/types/shared/apn.py
+++ b/src/courier/types/shared/apn.py
@@ -1,0 +1,11 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Union
+from typing_extensions import TypeAlias
+
+from .token import Token
+from .multiple_tokens import MultipleTokens
+
+__all__ = ["Apn"]
+
+Apn: TypeAlias = Union[Token, MultipleTokens]

--- a/src/courier/types/shared/multiple_tokens.py
+++ b/src/courier/types/shared/multiple_tokens.py
@@ -1,12 +1,15 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List
+from typing import List, Union
 
-from .token import Token
 from ..._models import BaseModel
 
 __all__ = ["MultipleTokens"]
 
 
 class MultipleTokens(BaseModel):
-    tokens: List[Token]
+    tokens: Union[str, List[str]]
+    """One device token, or an array of them.
+
+    The values are the token strings themselves — not objects.
+    """

--- a/src/courier/types/shared/user_profile.py
+++ b/src/courier/types/shared/user_profile.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 from pydantic import Field as FieldInfo
 
+from .apn import Apn
 from .expo import Expo
 from .slack import Slack
 from .aws_sns import AwsSns
@@ -36,7 +37,12 @@ class UserProfile(BaseModel):
 
     airship: Optional[AirshipProfile] = None
 
-    apn: Optional[str] = None
+    apn: Optional[Apn] = None
+    """Apple Push Notification device tokens.
+
+    Supply either a single `token` or a `tokens` value. A bare string is rejected by
+    the provider — the token must be wrapped in this object.
+    """
 
     aws_sns: Optional[AwsSns] = None
     """Routes a push notification through the AWS SNS provider.
@@ -61,6 +67,7 @@ class UserProfile(BaseModel):
     email_verified: Optional[bool] = None
 
     expo: Optional[Expo] = None
+    """Expo push tokens. Supply either a single `token` or a `tokens` value."""
 
     facebook_psid: Optional[str] = FieldInfo(alias="facebookPSID", default=None)
 

--- a/tests/api_resources/test_notifications.py
+++ b/tests/api_resources/test_notifications.py
@@ -242,48 +242,6 @@ class TestNotifications:
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
-    def test_method_duplicate(self, client: Courier) -> None:
-        notification = client.notifications.duplicate(
-            "id",
-        )
-        assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    def test_raw_response_duplicate(self, client: Courier) -> None:
-        response = client.notifications.with_raw_response.duplicate(
-            "id",
-        )
-
-        assert response.is_closed is True
-        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
-        notification = response.parse()
-        assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    def test_streaming_response_duplicate(self, client: Courier) -> None:
-        with client.notifications.with_streaming_response.duplicate(
-            "id",
-        ) as response:
-            assert not response.is_closed
-            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
-
-            notification = response.parse()
-            assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-        assert cast(Any, response.is_closed) is True
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    def test_path_params_duplicate(self, client: Courier) -> None:
-        with pytest.raises(ValueError, match=r"Expected a non-empty value for `id` but received ''"):
-            client.notifications.with_raw_response.duplicate(
-                "",
-            )
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
     def test_method_list_versions(self, client: Courier) -> None:
         notification = client.notifications.list_versions(
             id="id",
@@ -965,48 +923,6 @@ class TestAsyncNotifications:
     async def test_path_params_archive(self, async_client: AsyncCourier) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `id` but received ''"):
             await async_client.notifications.with_raw_response.archive(
-                "",
-            )
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    async def test_method_duplicate(self, async_client: AsyncCourier) -> None:
-        notification = await async_client.notifications.duplicate(
-            "id",
-        )
-        assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    async def test_raw_response_duplicate(self, async_client: AsyncCourier) -> None:
-        response = await async_client.notifications.with_raw_response.duplicate(
-            "id",
-        )
-
-        assert response.is_closed is True
-        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
-        notification = await response.parse()
-        assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    async def test_streaming_response_duplicate(self, async_client: AsyncCourier) -> None:
-        async with async_client.notifications.with_streaming_response.duplicate(
-            "id",
-        ) as response:
-            assert not response.is_closed
-            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
-
-            notification = await response.parse()
-            assert_matches_type(NotificationTemplateResponse, notification, path=["response"])
-
-        assert cast(Any, response.is_closed) is True
-
-    @pytest.mark.skip(reason="Mock server tests are disabled")
-    @parametrize
-    async def test_path_params_duplicate(self, async_client: AsyncCourier) -> None:
-        with pytest.raises(ValueError, match=r"Expected a non-empty value for `id` but received ''"):
-            await async_client.notifications.with_raw_response.duplicate(
                 "",
             )
 


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**1 endpoint(s) removed**

- `POST /notifications/{id}/duplicate` — Duplicate Notification Template


## What changed in this SDK

9 files changed, 29 insertions(+), 172 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                           |  2 +-
 api.md                                               |  2 +-
 src/courier/resources/notifications/notifications.py | 82 ---------------------------------------
 src/courier/types/__init__.py                        |  1 +
 src/courier/types/shared/__init__.py                 |  1 +
 src/courier/types/shared/apn.py                      | 11 ++++++
 src/courier/types/shared/multiple_tokens.py          |  9 +++--
 src/courier/types/shared/user_profile.py             |  9 ++++-
 tests/api_resources/test_notifications.py            | 84 ----------------------------------------
 9 files changed, 29 insertions(+), 172 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
