### PR TITLE
feat(api): document channel on journey send nodes [C-20309]

### DIFF
--- a/src/courier/types/journey_send_node.py
+++ b/src/courier/types/journey_send_node.py
@@ -105,6 +105,14 @@ class JourneySendNode(BaseModel):
 
     id: Optional[str] = None
 
+    channel: Optional[Literal["email", "sms", "push", "inbox", "slack", "msteams"]] = None
+    """The channel this node sends through.
+
+    Optional — when omitted, the field is absent from the node, including on `GET`;
+    nodes created before this field existed have it unset. Setting it makes the
+    node's channel explicit to any client reading the journey.
+    """
+
     conditions: Optional[JourneyConditionsField] = None
     """Condition spec for a journey node.
 

--- a/src/courier/types/journey_send_node_param.py
+++ b/src/courier/types/journey_send_node_param.py
@@ -106,6 +106,14 @@ class JourneySendNodeParam(TypedDict, total=False):
 
     id: str
 
+    channel: Literal["email", "sms", "push", "inbox", "slack", "msteams"]
+    """The channel this node sends through.
+
+    Optional — when omitted, the field is absent from the node, including on `GET`;
+    nodes created before this field existed have it unset. Setting it makes the
+    node's channel explicit to any client reading the journey.
+    """
+
     conditions: JourneyConditionsFieldParam
     """Condition spec for a journey node.
 

--- a/tests/api_resources/test_journeys.py
+++ b/tests/api_resources/test_journeys.py
@@ -85,6 +85,7 @@ class TestJourneys:
                     },
                     "type": "send",
                     "id": "send-1",
+                    "channel": "email",
                     "conditions": ["string", "string"],
                     "experiment": {
                         "bucketing_key": "x",
@@ -695,6 +696,7 @@ class TestAsyncJourneys:
                     },
                     "type": "send",
                     "id": "send-1",
+                    "channel": "email",
                     "conditions": ["string", "string"],
                     "experiment": {
                         "bucketing_key": "x",


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 18 insertions(+)

<details><summary>Files</summary>

```
 src/courier/types/journey_send_node.py       | 8 ++++++++
 src/courier/types/journey_send_node_param.py | 8 ++++++++
 tests/api_resources/test_journeys.py         | 2 ++
 3 files changed, 18 insertions(+)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
