### PR TITLE
fix(api): correct two Elemental field names the REST API rejects

### DIFF
--- a/src/courier/types/shared/elemental_image_node.py
+++ b/src/courier/types/shared/elemental_image_node.py
@@ -2,8 +2,6 @@
 
 from typing import Optional
 
-from pydantic import Field as FieldInfo
-
 from .alignment import Alignment
 from .elemental_base_node import ElementalBaseNode
 
@@ -19,7 +17,7 @@ class ElementalImageNode(ElementalBaseNode):
     align: Optional[Alignment] = None
     """The alignment of the image."""
 
-    alt_text: Optional[str] = FieldInfo(alias="altText", default=None)
+    alt_text: Optional[str] = None
     """Alternate text for the image."""
 
     border_color: Optional[str] = None

--- a/src/courier/types/shared/elemental_quote_node.py
+++ b/src/courier/types/shared/elemental_quote_node.py
@@ -2,8 +2,6 @@
 
 from typing import Optional
 
-from pydantic import Field as FieldInfo
-
 from .locales import Locales
 from .alignment import Alignment
 from .text_style import TextStyle
@@ -21,7 +19,7 @@ class ElementalQuoteNode(ElementalBaseNode):
     align: Optional[Alignment] = None
     """Alignment of the quote."""
 
-    border_color: Optional[str] = FieldInfo(alias="borderColor", default=None)
+    border_color: Optional[str] = None
     """CSS border color property. For example, `#fff`"""
 
     font_size: Optional[str] = None

--- a/src/courier/types/shared_params/elemental_image_node.py
+++ b/src/courier/types/shared_params/elemental_image_node.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Optional
-from typing_extensions import Required, Annotated
+from typing_extensions import Required
 
-from ..._utils import PropertyInfo
 from ..shared.alignment import Alignment
 from .elemental_base_node import ElementalBaseNode
 
@@ -21,7 +20,7 @@ class ElementalImageNode(ElementalBaseNode, total=False):
     align: Optional[Alignment]
     """The alignment of the image."""
 
-    alt_text: Annotated[Optional[str], PropertyInfo(alias="altText")]
+    alt_text: Optional[str]
     """Alternate text for the image."""
 
     border_color: Optional[str]

--- a/src/courier/types/shared_params/elemental_quote_node.py
+++ b/src/courier/types/shared_params/elemental_quote_node.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from typing import Optional
-from typing_extensions import Required, Annotated
+from typing_extensions import Required
 
 from .locales import Locales
-from ..._utils import PropertyInfo
 from ..shared.alignment import Alignment
 from ..shared.text_style import TextStyle
 from .elemental_base_node import ElementalBaseNode
@@ -23,7 +22,7 @@ class ElementalQuoteNode(ElementalBaseNode, total=False):
     align: Optional[Alignment]
     """Alignment of the quote."""
 
-    border_color: Annotated[Optional[str], PropertyInfo(alias="borderColor")]
+    border_color: Optional[str]
     """CSS border color property. For example, `#fff`"""
 
     font_size: Optional[str]


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

4 files changed, 6 insertions(+), 12 deletions(-)

<details><summary>Files</summary>

```
 src/courier/types/shared/elemental_image_node.py        | 4 +---
 src/courier/types/shared/elemental_quote_node.py        | 4 +---
 src/courier/types/shared_params/elemental_image_node.py | 5 ++---
 src/courier/types/shared_params/elemental_quote_node.py | 5 ++---
 4 files changed, 6 insertions(+), 12 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
