### PR TITLE
fix(api): text content is not required

### DIFF
--- a/src/courier/types/shared/elemental_text_node.py
+++ b/src/courier/types/shared/elemental_text_node.py
@@ -13,12 +13,6 @@ __all__ = ["ElementalTextNode"]
 class ElementalTextNode(ElementalBaseNode):
     """Represents a body of text to be rendered inside of the notification."""
 
-    content: str
-    """The text content displayed in the notification.
-
-    Either this field must be specified, or the elements field
-    """
-
     align: Optional[Literal["left", "center", "right"]] = None
     """Text alignment."""
 
@@ -27,6 +21,12 @@ class ElementalTextNode(ElementalBaseNode):
 
     color: Optional[str] = None
     """Specifies the color of text. Can be any valid css color value"""
+
+    content: Optional[str] = None
+    """The text content displayed in the notification.
+
+    Either this field must be specified, or the elements field
+    """
 
     font_size: Optional[str] = None
     """CSS px font size for this text block, e.g.

--- a/src/courier/types/shared_params/elemental_text_node.py
+++ b/src/courier/types/shared_params/elemental_text_node.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Optional
-from typing_extensions import Literal, Required
+from typing_extensions import Literal
 
 from .locales import Locales
 from ..shared.text_style import TextStyle
@@ -15,12 +15,6 @@ __all__ = ["ElementalTextNode"]
 class ElementalTextNode(ElementalBaseNode, total=False):
     """Represents a body of text to be rendered inside of the notification."""
 
-    content: Required[str]
-    """The text content displayed in the notification.
-
-    Either this field must be specified, or the elements field
-    """
-
     align: Literal["left", "center", "right"]
     """Text alignment."""
 
@@ -29,6 +23,12 @@ class ElementalTextNode(ElementalBaseNode, total=False):
 
     color: Optional[str]
     """Specifies the color of text. Can be any valid css color value"""
+
+    content: str
+    """The text content displayed in the notification.
+
+    Either this field must be specified, or the elements field
+    """
 
     font_size: Optional[str]
     """CSS px font size for this text block, e.g.


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

2 files changed, 13 insertions(+), 13 deletions(-)

<details><summary>Files</summary>

```
 src/courier/types/shared/elemental_text_node.py        | 12 ++++++------
 src/courier/types/shared_params/elemental_text_node.py | 14 +++++++-------
 2 files changed, 13 insertions(+), 13 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
